### PR TITLE
`lazy val logger` field should be transient

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/Logging.scala
+++ b/src/main/scala/com/typesafe/scalalogging/Logging.scala
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory
  */
 trait LazyLogging {
 
+  @transient
   protected lazy val logger: Logger =
     Logger(LoggerFactory.getLogger(getClass.getName))
 }


### PR DESCRIPTION
See also http://fdahms.com/2015/10/14/scala-and-the-transient-lazy-val-pattern/