### PR TITLE
Use marker inside macros in *Enabled methods

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -54,7 +54,7 @@ private object LoggerMacro {
   def errorMessageCauseMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], cause: c.Expr[Throwable]): c.universe.Tree = {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
-    q"if ($underlying.isErrorEnabled) $underlying.error($marker, $message, $cause)"
+    q"if ($underlying.isErrorEnabled($marker)) $underlying.error($marker, $message, $cause)"
   }
 
   def errorMessageArgsMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], args: c.Expr[Any]*): c.universe.Tree = {
@@ -62,9 +62,9 @@ private object LoggerMacro {
     val underlying = q"${c.prefix}.underlying"
     val anyRefArgs = formatArgs(c)(args: _*)
     if (args.length == 2)
-      q"if ($underlying.isErrorEnabled) $underlying.error($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
+      q"if ($underlying.isErrorEnabled($marker)) $underlying.error($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
     else
-      q"if ($underlying.isErrorEnabled) $underlying.error($marker, $message, ..$anyRefArgs)"
+      q"if ($underlying.isErrorEnabled($marker)) $underlying.error($marker, $message, ..$anyRefArgs)"
   }
 
   def errorCode(c: LoggerContext)(body: c.Expr[Unit]): c.universe.Tree = {
@@ -104,7 +104,7 @@ private object LoggerMacro {
   def warnMessageCauseMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], cause: c.Expr[Throwable]): c.universe.Tree = {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
-    q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, $cause)"
+    q"if ($underlying.isWarnEnabled($marker)) $underlying.warn($marker, $message, $cause)"
   }
 
   def warnMessageArgsMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], args: c.Expr[Any]*): c.universe.Tree = {
@@ -112,9 +112,9 @@ private object LoggerMacro {
     val underlying = q"${c.prefix}.underlying"
     val anyRefArgs = formatArgs(c)(args: _*)
     if (args.length == 2)
-      q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
+      q"if ($underlying.isWarnEnabled($marker)) $underlying.warn($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
     else
-      q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, ..$anyRefArgs)"
+      q"if ($underlying.isWarnEnabled($marker)) $underlying.warn($marker, $message, ..$anyRefArgs)"
   }
 
   def warnCode(c: LoggerContext)(body: c.Expr[Unit]): c.universe.Tree = {
@@ -154,7 +154,7 @@ private object LoggerMacro {
   def infoMessageCauseMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], cause: c.Expr[Throwable]): c.universe.Tree = {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
-    q"if ($underlying.isInfoEnabled) $underlying.info($marker, $message, $cause)"
+    q"if ($underlying.isInfoEnabled($marker)) $underlying.info($marker, $message, $cause)"
   }
 
   def infoMessageArgsMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], args: c.Expr[Any]*): c.universe.Tree = {
@@ -162,9 +162,9 @@ private object LoggerMacro {
     val underlying = q"${c.prefix}.underlying"
     val anyRefArgs = formatArgs(c)(args: _*)
     if (args.length == 2)
-      q"if ($underlying.isInfoEnabled) $underlying.info($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
+      q"if ($underlying.isInfoEnabled($marker)) $underlying.info($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
     else
-      q"if ($underlying.isInfoEnabled) $underlying.info($marker, $message, ..$anyRefArgs)"
+      q"if ($underlying.isInfoEnabled($marker)) $underlying.info($marker, $message, ..$anyRefArgs)"
   }
 
   def infoCode(c: LoggerContext)(body: c.Expr[Unit]): c.universe.Tree = {
@@ -204,7 +204,7 @@ private object LoggerMacro {
   def debugMessageCauseMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], cause: c.Expr[Throwable]): c.universe.Tree = {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
-    q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, $cause)"
+    q"if ($underlying.isDebugEnabled($marker)) $underlying.debug($marker, $message, $cause)"
   }
 
   def debugMessageArgsMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], args: c.Expr[Any]*): c.universe.Tree = {
@@ -212,9 +212,9 @@ private object LoggerMacro {
     val underlying = q"${c.prefix}.underlying"
     val anyRefArgs = formatArgs(c)(args: _*)
     if (args.length == 2)
-      q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
+      q"if ($underlying.isDebugEnabled($marker)) $underlying.debug($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
     else
-      q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, ..$anyRefArgs)"
+      q"if ($underlying.isDebugEnabled($marker)) $underlying.debug($marker, $message, ..$anyRefArgs)"
   }
 
   def debugCode(c: LoggerContext)(body: c.Expr[Unit]): c.universe.Tree = {
@@ -254,7 +254,7 @@ private object LoggerMacro {
   def traceMessageCauseMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], cause: c.Expr[Throwable]): c.universe.Tree = {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
-    q"if ($underlying.isTraceEnabled) $underlying.trace($marker, $message, $cause)"
+    q"if ($underlying.isTraceEnabled($marker)) $underlying.trace($marker, $message, $cause)"
   }
 
   def traceMessageArgsMarker(c: LoggerContext)(marker: c.Expr[Marker], message: c.Expr[String], args: c.Expr[Any]*): c.universe.Tree = {
@@ -262,9 +262,9 @@ private object LoggerMacro {
     val underlying = q"${c.prefix}.underlying"
     val anyRefArgs = formatArgs(c)(args: _*)
     if (args.length == 2)
-      q"if ($underlying.isTraceEnabled) $underlying.trace($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
+      q"if ($underlying.isTraceEnabled($marker)) $underlying.trace($marker, $message, _root_.scala.Array(${anyRefArgs.head}, ${anyRefArgs(1)}): _*)"
     else
-      q"if ($underlying.isTraceEnabled) $underlying.trace($marker, $message, ..$anyRefArgs)"
+      q"if ($underlying.isTraceEnabled($marker)) $underlying.trace($marker, $message, ..$anyRefArgs)"
   }
 
   def traceCode(c: LoggerContext)(body: c.Expr[Unit]): c.universe.Tree = {

--- a/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
@@ -50,7 +50,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isErrorEnabled) {
+    q"""if ($underlying.isErrorEnabled($marker)) {
           $underlying.error($marker, $canLogEv.logMessage($message, $a))
           $canLogEv.afterLog($a)
         }"""
@@ -60,7 +60,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isErrorEnabled) {
+    q"""if ($underlying.isErrorEnabled($marker)) {
           $underlying.error($marker, $canLogEv.logMessage($message, $a), $cause)
           $canLogEv.afterLog($a)
         }"""
@@ -71,12 +71,12 @@ private object LoggerTakingImplicitMacro {
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
     if (args.length == 2) {
-      q"""if ($underlying.isErrorEnabled) {
+      q"""if ($underlying.isErrorEnabled($marker)) {
           $underlying.error($marker, $canLogEv.logMessage($message, $a), List(${args(0)}, ${args(1)}): _*)
           $canLogEv.afterLog($a)
         }"""
     } else {
-      q"""if ($underlying.isErrorEnabled) {
+      q"""if ($underlying.isErrorEnabled($marker)) {
           $underlying.error($marker, $canLogEv.logMessage($message, $a), ..$args)
           $canLogEv.afterLog($a)
         }"""
@@ -126,7 +126,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isWarnEnabled) {
+    q"""if ($underlying.isWarnEnabled($marker)) {
           $underlying.warn($marker, $canLogEv.logMessage($message, $a))
           $canLogEv.afterLog($a)
         }"""
@@ -136,7 +136,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isWarnEnabled) {
+    q"""if ($underlying.isWarnEnabled($marker)) {
           $underlying.warn($marker, $canLogEv.logMessage($message, $a), $cause)
           $canLogEv.afterLog($a)
         }"""
@@ -147,12 +147,12 @@ private object LoggerTakingImplicitMacro {
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
     if (args.length == 2) {
-      q"""if ($underlying.isWarnEnabled) {
+      q"""if ($underlying.isWarnEnabled($marker)) {
           $underlying.warn($marker, $canLogEv.logMessage($message, $a), List(${args(0)}, ${args(1)}): _*)
           $canLogEv.afterLog($a)
         }"""
     } else {
-      q"""if ($underlying.isWarnEnabled) {
+      q"""if ($underlying.isWarnEnabled($marker)) {
           $underlying.warn($marker, $canLogEv.logMessage($message, $a), ..$args)
           $canLogEv.afterLog($a)
         }"""
@@ -202,7 +202,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isInfoEnabled) {
+    q"""if ($underlying.isInfoEnabled($marker)) {
           $underlying.info($marker, $canLogEv.logMessage($message, $a))
           $canLogEv.afterLog($a)
         }"""
@@ -212,7 +212,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isInfoEnabled) {
+    q"""if ($underlying.isInfoEnabled($marker)) {
           $underlying.info($marker, $canLogEv.logMessage($message, $a), $cause)
           $canLogEv.afterLog($a)
         }"""
@@ -223,12 +223,12 @@ private object LoggerTakingImplicitMacro {
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
     if (args.length == 2) {
-      q"""if ($underlying.isInfoEnabled) {
+      q"""if ($underlying.isInfoEnabled($marker)) {
           $underlying.info($marker, $canLogEv.logMessage($message, $a), List(${args(0)}, ${args(1)}): _*)
           $canLogEv.afterLog($a)
         }"""
     } else {
-      q"""if ($underlying.isInfoEnabled) {
+      q"""if ($underlying.isInfoEnabled($marker)) {
           $underlying.info($marker, $canLogEv.logMessage($message, $a), ..$args)
           $canLogEv.afterLog($a)
         }"""
@@ -278,7 +278,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isDebugEnabled) {
+    q"""if ($underlying.isDebugEnabled($marker)) {
           $underlying.debug($marker, $canLogEv.logMessage($message, $a))
           $canLogEv.afterLog($a)
         }"""
@@ -288,7 +288,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isDebugEnabled) {
+    q"""if ($underlying.isDebugEnabled($marker)) {
           $underlying.debug($marker, $canLogEv.logMessage($message, $a), $cause)
           $canLogEv.afterLog($a)
         }"""
@@ -299,12 +299,12 @@ private object LoggerTakingImplicitMacro {
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
     if (args.length == 2) {
-      q"""if ($underlying.isDebugEnabled) {
+      q"""if ($underlying.isDebugEnabled($marker)) {
           $underlying.debug($marker, $canLogEv.logMessage($message, $a), List(${args(0)}, ${args(1)}): _*)
           $canLogEv.afterLog($a)
         }"""
     } else {
-      q"""if ($underlying.isDebugEnabled) {
+      q"""if ($underlying.isDebugEnabled($marker)) {
           $underlying.debug($marker, $canLogEv.logMessage($message, $a), ..$args)
           $canLogEv.afterLog($a)
         }"""
@@ -354,7 +354,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isTraceEnabled) {
+    q"""if ($underlying.isTraceEnabled($marker)) {
           $underlying.trace($marker, $canLogEv.logMessage($message, $a))
           $canLogEv.afterLog($a)
         }"""
@@ -364,7 +364,7 @@ private object LoggerTakingImplicitMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
-    q"""if ($underlying.isTraceEnabled) {
+    q"""if ($underlying.isTraceEnabled($marker)) {
           $underlying.trace($marker, $canLogEv.logMessage($message, $a), $cause)
           $canLogEv.afterLog($a)
         }"""
@@ -375,12 +375,12 @@ private object LoggerTakingImplicitMacro {
     val underlying = q"${c.prefix}.underlying"
     val canLogEv = q"${c.prefix}.canLogEv"
     if (args.length == 2) {
-      q"""if ($underlying.isTraceEnabled) {
+      q"""if ($underlying.isTraceEnabled($marker)) {
           $underlying.trace($marker, $canLogEv.logMessage($message, $a), List(${args(0)}, ${args(1)}): _*)
           $canLogEv.afterLog($a)
         }"""
     } else {
-      q"""if ($underlying.isTraceEnabled) {
+      q"""if ($underlying.isTraceEnabled($marker)) {
           $underlying.trace($marker, $canLogEv.logMessage($message, $a), ..$args)
           $canLogEv.afterLog($a)
         }"""

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -381,7 +381,7 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
     }
   }
 
-  def fixture(p: Underlying => Boolean, isEnabled: Boolean) =
+  def fixture(p: Underlying => Marker => Boolean, isEnabled: Boolean) =
     new {
       val marker = DummyMarker
       val msg = "msg"
@@ -390,7 +390,7 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val arg2 = new Integer(1)
       val arg3 = "arg3"
       val underlying = mock[org.slf4j.Logger]
-      when(p(underlying)).thenReturn(isEnabled)
+      when(p(underlying)(marker)).thenReturn(isEnabled)
       val logger = Logger(underlying)
     }
 }


### PR DESCRIPTION
- Use `marker` inside macros in *Enabled methods
- fixes https://github.com/lightbend/scala-logging/issues/139