### PR TITLE
Upgrade 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 scala:
    - 2.12.8
    - 2.11.12
-   - 2.13.0-M5
+   - 2.13.0-RC2
 env:
 - JDK=oraclejdk8
 - JDK=openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,9 @@ scalacOptions ++= List(
   "-encoding", "UTF-8"
 )
 
+// TODO: drop when RC2 artifacts are available for mockito (or 2.13.0 final)
+conflictWarning := ConflictWarning.disable
+
 osgiSettings
 
 OsgiKeys.bundleSymbolicName := "com.typesafe.scala-logging"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,16 +2,18 @@ import sbt._
 
 object Version {
   val logback   = "1.2.3"
-  val mockito   = "1.10.19"
+  val mockito   = "1.4.6"
   val scala     = "2.12.8"
-  val crossScala = List(scala, "2.11.12", "2.13.0-M5")
-  val scalaTest = "3.0.6-SNAP6"  // only version available for 2.13.0-M4
+  val crossScala = List(scala, "2.11.12", "2.13.0-RC2")
+  val scalaTest = "3.0.8-RC4"
   val slf4j     = "1.7.26"
 }
 
 object Library {
   val logbackClassic                     = "ch.qos.logback" %  "logback-classic" % Version.logback
-  val mockitoAll                         = "org.mockito"    %  "mockito-all"     % Version.mockito
+  def mockitoScala(v: String)            =
+    if (v == "2.13.0-RC2") "org.mockito"    %  "mockito-scala_2.13.0-RC1"   % Version.mockito  // TODO: drop when RC2 artifacts are available (or 2.13.0 final)
+    else "org.mockito"    %%  "mockito-scala"  % Version.mockito
   def scalaReflect(scalaVersion: String) = "org.scala-lang" % "scala-reflect"    % scalaVersion
   val scalaTest                          = "org.scalatest"  %% "scalatest"       % Version.scalaTest
   val slf4jApi                           = "org.slf4j"      %  "slf4j-api"       % Version.slf4j
@@ -24,7 +26,7 @@ object Dependencies {
     scalaReflect(scalaVersion),
     slf4jApi,
     logbackClassic % "test",
-    mockitoAll     % "test",
+    mockitoScala(scalaVersion)   % "test",
     scalaTest      % "test"
   )
 }

--- a/src/main/scala/com/typesafe/scalalogging/package.scala
+++ b/src/main/scala/com/typesafe/scalalogging/package.scala
@@ -23,4 +23,5 @@ package object scalalogging {
   type Seq[+A] = scala.collection.immutable.Seq[A]
 
   type IndexedSeq[+A] = scala.collection.immutable.IndexedSeq[A]
+
 }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -18,7 +18,7 @@ package com.typesafe.scalalogging
 
 import java.io._
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.slf4j.{ Logger => Underlying }
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -24,7 +24,13 @@ import org.slf4j.{ Logger => Underlying }
 import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.mockito.MockitoSugar
 
-class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
+trait Varargs {
+  // TODO: we used to wrap in List(...): _*, which I assume was to force the varags method to be chosen.
+  // I encapsulated that here in something that works across 2.12/2.13.
+  def forceVarargs[T](xs: T*): scala.Seq[T] = scala.Seq(xs: _*)
+}
+
+class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
 
   // Error
 
@@ -58,7 +64,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(s"msg $arg1 $arg2")
-      verify(underlying).error("msg {} {}", List(arg1, arg2): _*)
+      verify(underlying).error("msg {} {}", forceVarargs(arg1, arg2): _*)
     }
 
   }
@@ -86,9 +92,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(msg, arg1)
-      verify(underlying).error(msg, List(arg1): _*)
+      verify(underlying).error(msg, arg1)
       logger.error(msg, arg1, arg2)
-      verify(underlying).error(msg, List(arg1, arg2): _*)
+      verify(underlying).error(msg, forceVarargs(arg1, arg2): _*)
       logger.error(msg, arg1, arg2, arg3)
       verify(underlying).error(msg, arg1, arg2, arg3)
     }
@@ -97,9 +103,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(msg, arg1)
-      verify(underlying, never).error(msg, List(arg1): _*)
+      verify(underlying, never).error(msg, arg1)
       logger.error(msg, arg1, arg2)
-      verify(underlying, never).error(msg, List(arg1, arg2): _*)
+      verify(underlying, never).error(msg, forceVarargs(arg1, arg2): _*)
       logger.error(msg, arg1, arg2, arg3)
       verify(underlying, never).error(msg, arg1, arg2, arg3)
     }
@@ -137,7 +143,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(s"msg $arg1 $arg2")
-      verify(underlying).warn("msg {} {}", List(arg1, arg2): _*)
+      verify(underlying).warn("msg {} {}", forceVarargs(arg1, arg2): _*)
     }
   }
 
@@ -164,9 +170,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying).warn(msg, List(arg1): _*)
+      verify(underlying).warn(msg, arg1)
       logger.warn(msg, arg1, arg2)
-      verify(underlying).warn(msg, List(arg1, arg2): _*)
+      verify(underlying).warn(msg, forceVarargs(arg1, arg2): _*)
       logger.warn(msg, arg1, arg2, arg3)
       verify(underlying).warn(msg, arg1, arg2, arg3)
     }
@@ -175,9 +181,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying, never).warn(msg, List(arg1): _*)
+      verify(underlying, never).warn(msg, arg1)
       logger.warn(msg, arg1, arg2)
-      verify(underlying, never).warn(msg, List(arg1, arg2): _*)
+      verify(underlying, never).warn(msg, forceVarargs(arg1, arg2): _*)
       logger.warn(msg, arg1, arg2, arg3)
       verify(underlying, never).warn(msg, arg1, arg2, arg3)
     }
@@ -215,7 +221,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(s"msg $arg1 $arg2")
-      verify(underlying).info("msg {} {}", List(arg1, arg2): _*)
+      verify(underlying).info("msg {} {}", forceVarargs(arg1, arg2): _*)
     }
   }
 
@@ -242,9 +248,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(msg, arg1)
-      verify(underlying).info(msg, List(arg1): _*)
+      verify(underlying).info(msg, arg1)
       logger.info(msg, arg1, arg2)
-      verify(underlying).info(msg, List(arg1, arg2): _*)
+      verify(underlying).info(msg, forceVarargs(arg1, arg2): _*)
       logger.info(msg, arg1, arg2, arg3)
       verify(underlying).info(msg, arg1, arg2, arg3)
     }
@@ -253,9 +259,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(msg, arg1)
-      verify(underlying, never).info(msg, List(arg1): _*)
+      verify(underlying, never).info(msg, arg1)
       logger.info(msg, arg1, arg2)
-      verify(underlying, never).info(msg, List(arg1, arg2): _*)
+      verify(underlying, never).info(msg, forceVarargs(arg1, arg2): _*)
       logger.info(msg, arg1, arg2, arg3)
       verify(underlying, never).info(msg, arg1, arg2, arg3)
     }
@@ -292,7 +298,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(s"msg $arg1 $arg2")
-      verify(underlying).debug("msg {} {}", List(arg1, arg2): _*)
+      verify(underlying).debug("msg {} {}", forceVarargs(arg1, arg2): _*)
     }
   }
 
@@ -319,9 +325,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying).debug(msg, List(arg1): _*)
+      verify(underlying).debug(msg, arg1)
       logger.debug(msg, arg1, arg2)
-      verify(underlying).debug(msg, List(arg1, arg2): _*)
+      verify(underlying).debug(msg, forceVarargs(arg1, arg2): _*)
       logger.debug(msg, arg1, arg2, arg3)
       verify(underlying).debug(msg, arg1, arg2, arg3)
     }
@@ -330,9 +336,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying, never).debug(msg, List(arg1): _*)
+      verify(underlying, never).debug(msg, arg1)
       logger.debug(msg, arg1, arg2)
-      verify(underlying, never).debug(msg, List(arg1, arg2): _*)
+      verify(underlying, never).debug(msg, forceVarargs(arg1, arg2): _*)
       logger.debug(msg, arg1, arg2, arg3)
       verify(underlying, never).debug(msg, arg1, arg2, arg3)
     }
@@ -370,7 +376,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(s"msg $arg1 $arg2")
-      verify(underlying).trace("msg {} {}", List(arg1, arg2): _*)
+      verify(underlying).trace("msg {} {}", forceVarargs(arg1, arg2): _*)
     }
   }
 
@@ -397,9 +403,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying).trace(msg, List(arg1): _*)
+      verify(underlying).trace(msg, arg1)
       logger.trace(msg, arg1, arg2)
-      verify(underlying).trace(msg, List(arg1, arg2): _*)
+      verify(underlying).trace(msg, forceVarargs(arg1, arg2): _*)
       logger.trace(msg, arg1, arg2, arg3)
       verify(underlying).trace(msg, arg1, arg2, arg3)
     }
@@ -408,9 +414,9 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying, never).trace(msg, List(arg1): _*)
+      verify(underlying, never).trace(msg, arg1)
       logger.trace(msg, arg1, arg2)
-      verify(underlying, never).trace(msg, List(arg1, arg2): _*)
+      verify(underlying, never).trace(msg, forceVarargs(arg1, arg2): _*)
       logger.trace(msg, arg1, arg2, arg3)
       verify(underlying, never).trace(msg, arg1, arg2, arg3)
     }
@@ -468,7 +474,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error("foo {}, bar {}", arg4, arg5)
-      verify(underlying).error("foo {}, bar {}", Array(arg4ref, arg5ref): _*)
+      verify(underlying).error("foo {}, bar {}", forceVarargs(arg4ref, arg5ref): _*)
     }
 
     "map args to AnyRef for non 2 args" in {

--- a/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
@@ -1,6 +1,6 @@
 package com.typesafe.scalalogging
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpec }
 import org.slf4j.{ Logger => Underlying }
 
-class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar {
+class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
 
   case class CorrelationId(value: String)
 
@@ -60,9 +60,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(msg, arg1)
-      verify(underlying).error(logMsg, List(arg1): _*)
+      verify(underlying).error(logMsg, arg1)
       logger.error(msg, arg1, arg2)
-      verify(underlying).error(logMsg, List(arg1, arg2): _*)
+      verify(underlying).error(logMsg, forceVarargs(arg1, arg2): _*)
       logger.error(msg, arg1, arg2, arg3)
       verify(underlying).error(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
@@ -73,9 +73,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(msg, arg1)
-      verify(underlying, never).error(logMsg, List(arg1): _*)
+      verify(underlying, never).error(logMsg, arg1)
       logger.error(msg, arg1, arg2)
-      verify(underlying, never).error(logMsg, List(arg1, arg2): _*)
+      verify(underlying, never).error(logMsg, forceVarargs(arg1, arg2): _*)
       logger.error(msg, arg1, arg2, arg3)
       verify(underlying, never).error(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
@@ -133,9 +133,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying).warn(logMsg, List(arg1): _*)
+      verify(underlying).warn(logMsg, arg1)
       logger.warn(msg, arg1, arg2)
-      verify(underlying).warn(logMsg, List(arg1, arg2): _*)
+      verify(underlying).warn(logMsg, forceVarargs(arg1, arg2): _*)
       logger.warn(msg, arg1, arg2, arg3)
       verify(underlying).warn(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
@@ -146,9 +146,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying, never).warn(logMsg, List(arg1): _*)
+      verify(underlying, never).warn(logMsg, arg1)
       logger.warn(msg, arg1, arg2)
-      verify(underlying, never).warn(logMsg, List(arg1, arg2): _*)
+      verify(underlying, never).warn(logMsg, forceVarargs(arg1, arg2): _*)
       logger.warn(msg, arg1, arg2, arg3)
       verify(underlying, never).warn(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
@@ -206,9 +206,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(msg, arg1)
-      verify(underlying).info(logMsg, List(arg1): _*)
+      verify(underlying).info(logMsg, arg1)
       logger.info(msg, arg1, arg2)
-      verify(underlying).info(logMsg, List(arg1, arg2): _*)
+      verify(underlying).info(logMsg, forceVarargs(arg1, arg2): _*)
       logger.info(msg, arg1, arg2, arg3)
       verify(underlying).info(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
@@ -219,9 +219,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(msg, arg1)
-      verify(underlying, never).info(logMsg, List(arg1): _*)
+      verify(underlying, never).info(logMsg, arg1)
       logger.info(msg, arg1, arg2)
-      verify(underlying, never).info(logMsg, List(arg1, arg2): _*)
+      verify(underlying, never).info(logMsg, forceVarargs(arg1, arg2): _*)
       logger.info(msg, arg1, arg2, arg3)
       verify(underlying, never).info(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
@@ -279,9 +279,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying).debug(logMsg, List(arg1): _*)
+      verify(underlying).debug(logMsg, arg1)
       logger.debug(msg, arg1, arg2)
-      verify(underlying).debug(logMsg, List(arg1, arg2): _*)
+      verify(underlying).debug(logMsg, forceVarargs(arg1, arg2): _*)
       logger.debug(msg, arg1, arg2, arg3)
       verify(underlying).debug(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
@@ -292,9 +292,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying, never).debug(logMsg, List(arg1): _*)
+      verify(underlying, never).debug(logMsg, arg1)
       logger.debug(msg, arg1, arg2)
-      verify(underlying, never).debug(logMsg, List(arg1, arg2): _*)
+      verify(underlying, never).debug(logMsg, forceVarargs(arg1, arg2): _*)
       logger.debug(msg, arg1, arg2, arg3)
       verify(underlying, never).debug(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
@@ -352,9 +352,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying).trace(logMsg, List(arg1): _*)
+      verify(underlying).trace(logMsg, arg1)
       logger.trace(msg, arg1, arg2)
-      verify(underlying).trace(logMsg, List(arg1, arg2): _*)
+      verify(underlying).trace(logMsg, forceVarargs(arg1, arg2): _*)
       logger.trace(msg, arg1, arg2, arg3)
       verify(underlying).trace(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
@@ -365,9 +365,9 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying, never).trace(logMsg, List(arg1): _*)
+      verify(underlying, never).trace(logMsg, arg1)
       logger.trace(msg, arg1, arg2)
-      verify(underlying, never).trace(logMsg, List(arg1, arg2): _*)
+      verify(underlying, never).trace(logMsg, forceVarargs(arg1, arg2): _*)
       logger.trace(msg, arg1, arg2, arg3)
       verify(underlying, never).trace(logMsg, arg1, arg2, arg3)
       verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -17,7 +17,7 @@
 package com.typesafe.scalalogging
 
 import java.util.NoSuchElementException
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.slf4j.{ Logger => Underlying }
 import org.slf4j.Marker

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -39,7 +39,7 @@ object DummyMarker extends Marker {
   def remove(child: Marker): Boolean = false
 }
 
-class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
+class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
 
   // Error
 
@@ -90,9 +90,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(marker, msg, arg1)
-      verify(underlying).error(marker, msg, List(arg1): _*)
+      verify(underlying).error(marker, msg, arg1)
       logger.error(marker, msg, arg1, arg2)
-      verify(underlying).error(marker, msg, List(arg1, arg2): _*)
+      verify(underlying).error(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.error(marker, msg, arg1, arg2, arg3)
       verify(underlying).error(marker, msg, arg1, arg2, arg3)
     }
@@ -101,9 +101,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(marker, msg, arg1)
-      verify(underlying, never).error(marker, msg, List(arg1): _*)
+      verify(underlying, never).error(marker, msg, arg1)
       logger.error(marker, msg, arg1, arg2)
-      verify(underlying, never).error(marker, msg, List(arg1, arg2): _*)
+      verify(underlying, never).error(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.error(marker, msg, arg1, arg2, arg3)
       verify(underlying, never).error(marker, msg, arg1, arg2, arg3)
     }
@@ -158,9 +158,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(marker, msg, arg1)
-      verify(underlying).warn(marker, msg, List(arg1): _*)
+      verify(underlying).warn(marker, msg, arg1)
       logger.warn(marker, msg, arg1, arg2)
-      verify(underlying).warn(marker, msg, List(arg1, arg2): _*)
+      verify(underlying).warn(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.warn(marker, msg, arg1, arg2, arg3)
       verify(underlying).warn(marker, msg, arg1, arg2, arg3)
     }
@@ -169,9 +169,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(marker, msg, arg1)
-      verify(underlying, never).warn(marker, msg, List(arg1): _*)
+      verify(underlying, never).warn(marker, msg, arg1)
       logger.warn(marker, msg, arg1, arg2)
-      verify(underlying, never).warn(marker, msg, List(arg1, arg2): _*)
+      verify(underlying, never).warn(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.warn(marker, msg, arg1, arg2, arg3)
       verify(underlying, never).warn(marker, msg, arg1, arg2, arg3)
     }
@@ -226,9 +226,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(marker, msg, arg1)
-      verify(underlying).info(marker, msg, List(arg1): _*)
+      verify(underlying).info(marker, msg, arg1)
       logger.info(marker, msg, arg1, arg2)
-      verify(underlying).info(marker, msg, List(arg1, arg2): _*)
+      verify(underlying).info(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.info(marker, msg, arg1, arg2, arg3)
       verify(underlying).info(marker, msg, arg1, arg2, arg3)
     }
@@ -237,9 +237,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(marker, msg, arg1)
-      verify(underlying, never).info(marker, msg, List(arg1): _*)
+      verify(underlying, never).info(marker, msg, arg1)
       logger.info(marker, msg, arg1, arg2)
-      verify(underlying, never).info(marker, msg, List(arg1, arg2): _*)
+      verify(underlying, never).info(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.info(marker, msg, arg1, arg2, arg3)
       verify(underlying, never).info(marker, msg, arg1, arg2, arg3)
     }
@@ -294,9 +294,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(marker, msg, arg1)
-      verify(underlying).debug(marker, msg, List(arg1): _*)
+      verify(underlying).debug(marker, msg, arg1)
       logger.debug(marker, msg, arg1, arg2)
-      verify(underlying).debug(marker, msg, List(arg1, arg2): _*)
+      verify(underlying).debug(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.debug(marker, msg, arg1, arg2, arg3)
       verify(underlying).debug(marker, msg, arg1, arg2, arg3)
     }
@@ -305,9 +305,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(marker, msg, arg1)
-      verify(underlying, never).debug(marker, msg, List(arg1): _*)
+      verify(underlying, never).debug(marker, msg, arg1)
       logger.debug(marker, msg, arg1, arg2)
-      verify(underlying, never).debug(marker, msg, List(arg1, arg2): _*)
+      verify(underlying, never).debug(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.debug(marker, msg, arg1, arg2, arg3)
       verify(underlying, never).debug(marker, msg, arg1, arg2, arg3)
     }
@@ -362,9 +362,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(marker, msg, arg1)
-      verify(underlying).trace(marker, msg, List(arg1): _*)
+      verify(underlying).trace(marker, msg, arg1)
       logger.trace(marker, msg, arg1, arg2)
-      verify(underlying).trace(marker, msg, List(arg1, arg2): _*)
+      verify(underlying).trace(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.trace(marker, msg, arg1, arg2, arg3)
       verify(underlying).trace(marker, msg, arg1, arg2, arg3)
     }
@@ -373,9 +373,9 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(marker, msg, arg1)
-      verify(underlying, never).trace(marker, msg, List(arg1): _*)
+      verify(underlying, never).trace(marker, msg, arg1)
       logger.trace(marker, msg, arg1, arg2)
-      verify(underlying, never).trace(marker, msg, List(arg1, arg2): _*)
+      verify(underlying, never).trace(marker, msg, forceVarargs(arg1, arg2): _*)
       logger.trace(marker, msg, arg1, arg2, arg3)
       verify(underlying, never).trace(marker, msg, arg1, arg2, arg3)
     }


### PR DESCRIPTION
Upgrade to 2.13.0-RC2 (note: there's a temporary hack to use RC1 artifacts for mockit-scala).

Also clarify (hopefully correctly) use of varargs (not really related to the 2.13 upgrade, but somehow it broke). /cc @szeiger, maybe you have an idea why? (something to do with the switch to immutable seq for varargs?)