### PR TITLE
Version upgrade: Scala 2.13.0-RC3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 scala:
    - 2.12.8
    - 2.11.12
-   - 2.13.0-RC2
+   - 2.13.0-RC3
 env:
 - JDK=oraclejdk8
 - JDK=openjdk8

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,17 +2,17 @@ import sbt._
 
 object Version {
   val logback   = "1.2.3"
-  val mockito   = "1.4.6"
+  val mockito   = "1.5.0"
   val scala     = "2.12.8"
-  val crossScala = List(scala, "2.11.12", "2.13.0-RC2")
-  val scalaTest = "3.0.8-RC4"
+  val crossScala = List(scala, "2.11.12", "2.13.0-RC3")
+  val scalaTest = "3.0.8-RC5"
   val slf4j     = "1.7.26"
 }
 
 object Library {
   val logbackClassic                     = "ch.qos.logback" %  "logback-classic" % Version.logback
   def mockitoScala(v: String)            =
-    if (v == "2.13.0-RC2") "org.mockito"    %  "mockito-scala_2.13.0-RC1"   % Version.mockito  // TODO: drop when RC2 artifacts are available (or 2.13.0 final)
+    if (v == "2.13.0-RC3") "org.mockito"    %  "mockito-scala_2.13.0-RC2"   % Version.mockito  // TODO: drop when RC3 artifacts are available (or 2.13.0 final)
     else "org.mockito"    %%  "mockito-scala"  % Version.mockito
   def scalaReflect(scalaVersion: String) = "org.scala-lang" % "scala-reflect"    % scalaVersion
   val scalaTest                          = "org.scalatest"  %% "scalatest"       % Version.scalaTest


### PR DESCRIPTION
details:
- Scala:    2.13.0-RC2 -->> 2.13.0-RC3
- mockito-scala: 1.4.6 -->> 1.5.0 https://github.com/mockito/mockito-scala/blob/v1.5.0/docs/release-notes.md
- scalatest: 3.0.8-RC4 -->> 3.0.8-RC5