### PR TITLE
Use mockito-scala syntax 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,11 +10,11 @@ object Version {
 }
 
 object Library {
-  val logbackClassic                     = "ch.qos.logback" %  "logback-classic" % Version.logback
-  val mockitoScala                       = "org.mockito"    %% "mockito-scala"   % Version.mockito
-  def scalaReflect(scalaVersion: String) = "org.scala-lang" %  "scala-reflect"   % scalaVersion
-  val scalaTest                          = "org.scalatest"  %% "scalatest"       % Version.scalaTest
-  val slf4jApi                           = "org.slf4j"      %  "slf4j-api"       % Version.slf4j
+  val logbackClassic                     = "ch.qos.logback" %  "logback-classic"         % Version.logback
+  val mockitoScala                       = "org.mockito"    %% "mockito-scala-scalatest" % Version.mockito
+  def scalaReflect(scalaVersion: String) = "org.scala-lang" %  "scala-reflect"           % scalaVersion
+  val scalaTest                          = "org.scalatest"  %% "scalatest"               % Version.scalaTest
+  val slf4jApi                           = "org.slf4j"      %  "slf4j-api"               % Version.slf4j
 }
 
 object Dependencies {

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -18,11 +18,9 @@ package com.typesafe.scalalogging
 
 import java.io._
 
-import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
-import org.slf4j.{ Logger => Underlying }
+import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.{ Matchers, WordSpec }
-import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.{ Logger => Underlying }
 
 trait Varargs {
   // TODO: we used to wrap in List(...): _*, which I assume was to force the varags method to be chosen.
@@ -30,41 +28,45 @@ trait Varargs {
   def forceVarargs[T](xs: T*): scala.Seq[T] = scala.Seq(xs: _*)
 }
 
-class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
+class LoggerSpec
+  extends WordSpec
+  with Matchers
+  with IdiomaticMockito
+  with Varargs {
 
   // Error
 
   "Calling error with a message" should {
 
     "call the underlying logger's error method if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(msg)
-      verify(underlying).error(msg)
+      underlying.error(msg) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled returns false)
       import f._
       logger.error(msg)
-      verify(underlying, never).error(anyString)
+      underlying.error(*) wasNever called
     }
   }
 
   "Calling error with an interpolated message" should {
 
     "call the underlying logger's error method with arguments if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"msg $arg1 $arg2 $arg3")
-      verify(underlying).error("msg {} {} {}", arg1, arg2, arg3)
+      underlying.error("msg {} {} {}", arg1, arg2, arg3) was called
     }
 
     "call the underlying logger's error method with two arguments if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"msg $arg1 $arg2")
-      verify(underlying).error("msg {} {}", forceVarargs(arg1, arg2): _*)
+      underlying.error("msg {} {}", forceVarargs(arg1, arg2): _*) was called
     }
 
   }
@@ -72,42 +74,42 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
   "Calling error with a message and cause" should {
 
     "call the underlying logger's error method if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(msg, cause)
-      verify(underlying).error(msg, cause)
+      underlying.error(msg, cause) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled returns false)
       import f._
       logger.error(msg, cause)
-      verify(underlying, never).error(anyString, any[Object])
+      underlying.error(*, any[Object]) wasNever called
     }
   }
 
   "Calling error with a message and parameters" should {
 
     "call the underlying logger's error method if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(msg, arg1)
-      verify(underlying).error(msg, arg1)
+      underlying.error(msg, arg1) was called
       logger.error(msg, arg1, arg2)
-      verify(underlying).error(msg, forceVarargs(arg1, arg2): _*)
+      underlying.error(msg, forceVarargs(arg1, arg2): _*) was called
       logger.error(msg, arg1, arg2, arg3)
-      verify(underlying).error(msg, arg1, arg2, arg3)
+      underlying.error(msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled returns false)
       import f._
       logger.error(msg, arg1)
-      verify(underlying, never).error(msg, arg1)
+      underlying.error(msg, arg1) wasNever called
       logger.error(msg, arg1, arg2)
-      verify(underlying, never).error(msg, forceVarargs(arg1, arg2): _*)
+      underlying.error(msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.error(msg, arg1, arg2, arg3)
-      verify(underlying, never).error(msg, arg1, arg2, arg3)
+      underlying.error(msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -116,76 +118,76 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
   "Calling warn with a message" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(msg)
-      verify(underlying).warn(msg)
+      underlying.warn(msg) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled returns false)
       import f._
       logger.warn(msg)
-      verify(underlying, never).warn(anyString)
+      underlying.warn(*) wasNever called
     }
   }
 
   "Calling warn with an interpolated message" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(s"msg $arg1 $arg2 $arg3")
-      verify(underlying).warn("msg {} {} {}", arg1, arg2, arg3)
+      underlying.warn("msg {} {} {}", arg1, arg2, arg3) was called
     }
 
     "call the underlying logger's warn method with two arguments if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(s"msg $arg1 $arg2")
-      verify(underlying).warn("msg {} {}", forceVarargs(arg1, arg2): _*)
+      underlying.warn("msg {} {}", forceVarargs(arg1, arg2): _*) was called
     }
   }
 
   "Calling warn with a message and cause" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(msg, cause)
-      verify(underlying).warn(msg, cause)
+      underlying.warn(msg, cause) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled returns false)
       import f._
       logger.warn(msg, cause)
-      verify(underlying, never).warn(anyString, any[Object])
+      underlying.warn(*, any[Object]) wasNever called
     }
   }
 
   "Calling warn with a message and parameters" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying).warn(msg, arg1)
+      underlying.warn(msg, arg1) was called
       logger.warn(msg, arg1, arg2)
-      verify(underlying).warn(msg, forceVarargs(arg1, arg2): _*)
+      underlying.warn(msg, forceVarargs(arg1, arg2): _*) was called
       logger.warn(msg, arg1, arg2, arg3)
-      verify(underlying).warn(msg, arg1, arg2, arg3)
+      underlying.warn(msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled returns false)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying, never).warn(msg, arg1)
+      underlying.warn(msg, arg1) wasNever called
       logger.warn(msg, arg1, arg2)
-      verify(underlying, never).warn(msg, forceVarargs(arg1, arg2): _*)
+      underlying.warn(msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.warn(msg, arg1, arg2, arg3)
-      verify(underlying, never).warn(msg, arg1, arg2, arg3)
+      underlying.warn(msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -194,76 +196,76 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
   "Calling info with a message" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(msg)
-      verify(underlying).info(msg)
+      underlying.info(msg) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled returns false)
       import f._
       logger.info(msg)
-      verify(underlying, never).info(anyString)
+      underlying.info(*) wasNever called
     }
   }
 
   "Calling info with an interpolated message" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(s"msg $arg1 $arg2 $arg3")
-      verify(underlying).info("msg {} {} {}", arg1, arg2, arg3)
+      underlying.info("msg {} {} {}", arg1, arg2, arg3) was called
     }
 
     "call the underlying logger's info method with two arguments if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(s"msg $arg1 $arg2")
-      verify(underlying).info("msg {} {}", forceVarargs(arg1, arg2): _*)
+      underlying.info("msg {} {}", forceVarargs(arg1, arg2): _*) was called
     }
   }
 
   "Calling info with a message and cause" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(msg, cause)
-      verify(underlying).info(msg, cause)
+      underlying.info(msg, cause) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled returns false)
       import f._
       logger.info(msg, cause)
-      verify(underlying, never).info(anyString, any[Object])
+      underlying.info(*, any[Object]) wasNever called
     }
   }
 
   "Calling info with a message and parameters" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(msg, arg1)
-      verify(underlying).info(msg, arg1)
+      underlying.info(msg, arg1) was called
       logger.info(msg, arg1, arg2)
-      verify(underlying).info(msg, forceVarargs(arg1, arg2): _*)
+      underlying.info(msg, forceVarargs(arg1, arg2): _*) was called
       logger.info(msg, arg1, arg2, arg3)
-      verify(underlying).info(msg, arg1, arg2, arg3)
+      underlying.info(msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled returns false)
       import f._
       logger.info(msg, arg1)
-      verify(underlying, never).info(msg, arg1)
+      underlying.info(msg, arg1) wasNever called
       logger.info(msg, arg1, arg2)
-      verify(underlying, never).info(msg, forceVarargs(arg1, arg2): _*)
+      underlying.info(msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.info(msg, arg1, arg2, arg3)
-      verify(underlying, never).info(msg, arg1, arg2, arg3)
+      underlying.info(msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -272,75 +274,75 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
   "Calling debug with a message" should {
 
     "call the underlying logger's debug method if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(msg)
-      verify(underlying).debug(msg)
+      underlying.debug(msg) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled returns false)
       import f._
       logger.debug(msg)
-      verify(underlying, never).debug(anyString)
+      underlying.debug(*) wasNever called
     }
   }
   "Calling debug with an interpolated message" should {
 
     "call the underlying logger's debug method if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(s"msg $arg1 $arg2 $arg3")
-      verify(underlying).debug("msg {} {} {}", arg1, arg2, arg3)
+      underlying.debug("msg {} {} {}", arg1, arg2, arg3) was called
     }
 
     "call the underlying logger's debug method with two arguments if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(s"msg $arg1 $arg2")
-      verify(underlying).debug("msg {} {}", forceVarargs(arg1, arg2): _*)
+      underlying.debug("msg {} {}", forceVarargs(arg1, arg2): _*) was called
     }
   }
 
   "Calling debug with a message and cause" should {
 
     "call the underlying logger's debug method if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(msg, cause)
-      verify(underlying).debug(msg, cause)
+      underlying.debug(msg, cause) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled returns false)
       import f._
       logger.debug(msg, cause)
-      verify(underlying, never).debug(anyString, any[Object])
+      underlying.debug(*, any[Object]) wasNever called
     }
   }
 
   "Calling debug with a message and parameters" should {
 
     "call the underlying logger's debug method if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying).debug(msg, arg1)
+      underlying.debug(msg, arg1) was called
       logger.debug(msg, arg1, arg2)
-      verify(underlying).debug(msg, forceVarargs(arg1, arg2): _*)
+      underlying.debug(msg, forceVarargs(arg1, arg2): _*) was called
       logger.debug(msg, arg1, arg2, arg3)
-      verify(underlying).debug(msg, arg1, arg2, arg3)
+      underlying.debug(msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled returns false)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying, never).debug(msg, arg1)
+      underlying.debug(msg, arg1) wasNever called
       logger.debug(msg, arg1, arg2)
-      verify(underlying, never).debug(msg, forceVarargs(arg1, arg2): _*)
+      underlying.debug(msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.debug(msg, arg1, arg2, arg3)
-      verify(underlying, never).debug(msg, arg1, arg2, arg3)
+      underlying.debug(msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -349,76 +351,76 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
   "Calling trace with a message" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(msg)
-      verify(underlying).trace(msg)
+      underlying.trace(msg) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled returns false)
       import f._
       logger.trace(msg)
-      verify(underlying, never).trace(anyString)
+      underlying.trace(*) wasNever called
     }
   }
 
   "Calling trace with an interpolated message" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(s"msg $arg1 $arg2 $arg3")
-      verify(underlying).trace("msg {} {} {}", arg1, arg2, arg3)
+      underlying.trace("msg {} {} {}", arg1, arg2, arg3) was called
     }
 
     "call the underlying logger's trace method with two arguments if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(s"msg $arg1 $arg2")
-      verify(underlying).trace("msg {} {}", forceVarargs(arg1, arg2): _*)
+      underlying.trace("msg {} {}", forceVarargs(arg1, arg2): _*) was called
     }
   }
 
   "Calling trace with a message and cause" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(msg, cause)
-      verify(underlying).trace(msg, cause)
+      underlying.trace(msg, cause) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled returns false)
       import f._
       logger.trace(msg, cause)
-      verify(underlying, never).trace(anyString, any[Object])
+      underlying.trace(*, any[Object]) wasNever called
     }
   }
 
   "Calling trace with a message and parameters" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying).trace(msg, arg1)
+      underlying.trace(msg, arg1) was called
       logger.trace(msg, arg1, arg2)
-      verify(underlying).trace(msg, forceVarargs(arg1, arg2): _*)
+      underlying.trace(msg, forceVarargs(arg1, arg2): _*) was called
       logger.trace(msg, arg1, arg2, arg3)
-      verify(underlying).trace(msg, arg1, arg2, arg3)
+      underlying.trace(msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled returns false)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying, never).trace(msg, arg1)
+      underlying.trace(msg, arg1) wasNever called
       logger.trace(msg, arg1, arg2)
-      verify(underlying, never).trace(msg, forceVarargs(arg1, arg2): _*)
+      underlying.trace(msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.trace(msg, arg1, arg2, arg3)
-      verify(underlying, never).trace(msg, arg1, arg2, arg3)
+      underlying.trace(msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -427,63 +429,63 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
   "Logging a message using the standard string interpolator" should {
 
     "call the underlying format method with boxed versions of value arguments" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"msg ${1}")
-      verify(underlying).error("msg {}", 1.asInstanceOf[AnyRef])
+      underlying.error("msg {}", 1.asInstanceOf[AnyRef]) was called
     }
 
     "call the underlying format method with boxed versions of arguments of type Any" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"msg ${1.asInstanceOf[Any]}")
-      verify(underlying).error("msg {}", 1.asInstanceOf[AnyRef])
+      underlying.error("msg {}", 1.asInstanceOf[AnyRef]) was called
     }
 
     "call the underlying format method escaping literal format anchors" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"foo {} bar $arg1")
-      verify(underlying).error("foo \\{} bar {}", arg1)
+      underlying.error("foo \\{} bar {}", arg1) was called
     }
 
     "call the underlying method without escaping format anchors when the message has no interpolations" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"foo {} bar")
-      verify(underlying).error("foo {} bar")
+      underlying.error("foo {} bar") was called
     }
 
     "call the underlying format method when the interpolated string contains escape sequences" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"foo\nbar $arg1")
-      verify(underlying).error(s"foo\nbar {}", arg1)
+      underlying.error(s"foo\nbar {}", arg1) was called
     }
 
     "call the underlying format method when the interpolated string is triple quoted and contains escape sequences" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(s"""foo\nbar $arg1""")
-      verify(underlying).error(s"""foo\nbar {}""", arg1)
+      underlying.error(s"""foo\nbar {}""", arg1) was called
     }
   }
 
   "Logging a message using slf4 interpolator and Any args" should {
     "map args to AnyRef for 2 args" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error("foo {}, bar {}", arg4, arg5)
-      verify(underlying).error("foo {}, bar {}", forceVarargs(arg4ref, arg5ref): _*)
+      underlying.error("foo {}, bar {}", forceVarargs(arg4ref, arg5ref): _*) was called
     }
 
     "map args to AnyRef for non 2 args" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error("foo {}", arg4)
-      verify(underlying).error("foo {}", arg4ref)
+      underlying.error("foo {}", arg4ref) was called
       logger.error("foo {}, bar {}, {}", arg4, arg5, arg6)
-      verify(underlying).error("foo {}, bar {}, {}", arg4ref, arg5ref, arg6ref)
+      underlying.error("foo {}, bar {}, {}", arg4ref, arg5ref, arg6ref) was called
     }
   }
 
@@ -512,7 +514,8 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
     }
 
     "be usable after deserialization" in {
-      val logger = deserialize(serialize(Logger(org.slf4j.LoggerFactory.getLogger("test"))))
+      val logger = deserialize(
+        serialize(Logger(org.slf4j.LoggerFactory.getLogger("test"))))
 
       logger.trace("Back from deserialization")
     }
@@ -532,10 +535,12 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
 
   "Serializing LoggerTakingImplicit" should {
     case class CorrelationId(value: String)
-    implicit val correlationId: CorrelationId = CorrelationId(value = "correlationId")
+    implicit val correlationId: CorrelationId =
+      CorrelationId(value = "correlationId")
 
     implicit case object canLogCorrelationId extends CanLog[CorrelationId] {
-      def logMessage(originalMsg: String, a: CorrelationId): String = s"${a.value} $originalMsg"
+      def logMessage(originalMsg: String, a: CorrelationId): String =
+        s"${a.value} $originalMsg"
     }
 
     def serialize[A](logger: LoggerTakingImplicit[A]): Array[Byte] = {
@@ -574,8 +579,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
       val logger =
         deserialize[CorrelationId](
           serialize[CorrelationId](
-            Logger.takingImplicit[CorrelationId](
-              classOf[LoggerSpec])))
+            Logger.takingImplicit[CorrelationId](classOf[LoggerSpec])))
 
       logger.trace("Back from deserialization")
     }
@@ -590,7 +594,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
     }
   }
 
-  def fixture(p: Underlying => Boolean, isEnabled: Boolean) =
+  def fixture(p: Underlying => Unit) =
     new {
       val msg = "msg"
       val cause = new RuntimeException("cause")
@@ -604,7 +608,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
       val arg6 = 6L
       val arg6ref = arg6.asInstanceOf[AnyRef]
       val underlying = mock[org.slf4j.Logger]
-      when(p(underlying)).thenReturn(isEnabled)
+      p(underlying)
       val logger = Logger(underlying)
     }
 }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
@@ -1,12 +1,14 @@
 package com.typesafe.scalalogging
 
-import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.{ Matchers, WordSpec }
 import org.slf4j.{ Logger => Underlying }
 
-class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
+class LoggerTakingImplicitSpec
+  extends WordSpec
+  with Matchers
+  with IdiomaticMockito
+  with Varargs {
 
   case class CorrelationId(value: String)
 
@@ -15,71 +17,71 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
   "Calling error with a message" should {
 
     "call the underlying logger's error method if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(msg)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).error(logMsg)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.error(logMsg) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled returns false)
       import f._
       logger.error(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).error(anyString)
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.error(*) wasNever called
     }
   }
 
   "Calling error with a message and cause" should {
 
     "call the underlying logger's error method if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(msg, cause)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).error(logMsg, cause)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.error(logMsg, cause) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled returns false)
       import f._
       logger.error(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).error(anyString, any[Object])
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.error(*, any[Object]) wasNever called
     }
   }
 
   "Calling error with a message and parameters" should {
 
     "call the underlying logger's error method if the error level is enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      val f = fixture(_.isErrorEnabled returns true)
       import f._
       logger.error(msg, arg1)
-      verify(underlying).error(logMsg, arg1)
+      underlying.error(logMsg, arg1) was called
       logger.error(msg, arg1, arg2)
-      verify(underlying).error(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.error(logMsg, forceVarargs(arg1, arg2): _*) was called
       logger.error(msg, arg1, arg2, arg3)
-      verify(underlying).error(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
-      verify(canLogCorrelationId, times(3)).afterLog(correlationId)
+      underlying.error(logMsg, arg1, arg2, arg3) was called
+      canLogCorrelationId.logMessage(msg, correlationId) wasCalled threeTimes
+      canLogCorrelationId.afterLog(correlationId) wasCalled threeTimes
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled returns false)
       import f._
       logger.error(msg, arg1)
-      verify(underlying, never).error(logMsg, arg1)
+      underlying.error(logMsg, arg1) wasNever called
       logger.error(msg, arg1, arg2)
-      verify(underlying, never).error(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.error(logMsg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.error(msg, arg1, arg2, arg3)
-      verify(underlying, never).error(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
+      underlying.error(logMsg, arg1, arg2, arg3) wasNever called
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
     }
   }
 
@@ -88,71 +90,71 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
   "Calling warn with a message" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(msg)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).warn(logMsg)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.warn(logMsg) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled returns false)
       import f._
       logger.warn(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).warn(anyString)
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.warn(*) wasNever called
     }
   }
 
   "Calling warn with a message and cause" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(msg, cause)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).warn(logMsg, cause)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.warn(logMsg, cause) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled returns false)
       import f._
       logger.warn(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).warn(anyString, any[Object])
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.warn(*, any[Object]) wasNever called
     }
   }
 
   "Calling warn with a message and parameters" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = true)
+      val f = fixture(_.isWarnEnabled returns true)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying).warn(logMsg, arg1)
+      underlying.warn(logMsg, arg1) was called
       logger.warn(msg, arg1, arg2)
-      verify(underlying).warn(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.warn(logMsg, forceVarargs(arg1, arg2): _*) was called
       logger.warn(msg, arg1, arg2, arg3)
-      verify(underlying).warn(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
-      verify(canLogCorrelationId, times(3)).afterLog(correlationId)
+      underlying.warn(logMsg, arg1, arg2, arg3) was called
+      canLogCorrelationId.logMessage(msg, correlationId) wasCalled threeTimes
+      canLogCorrelationId.afterLog(correlationId) wasCalled threeTimes
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled returns false)
       import f._
       logger.warn(msg, arg1)
-      verify(underlying, never).warn(logMsg, arg1)
+      underlying.warn(logMsg, arg1) wasNever called
       logger.warn(msg, arg1, arg2)
-      verify(underlying, never).warn(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.warn(logMsg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.warn(msg, arg1, arg2, arg3)
-      verify(underlying, never).warn(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
+      underlying.warn(logMsg, arg1, arg2, arg3) wasNever called
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
     }
   }
 
@@ -161,71 +163,71 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
   "Calling info with a message" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(msg)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).info(logMsg)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.info(logMsg) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled returns false)
       import f._
       logger.info(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).info(anyString)
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.info(*) wasNever called
     }
   }
 
   "Calling info with a message and cause" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(msg, cause)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).info(logMsg, cause)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.info(logMsg, cause) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled returns false)
       import f._
       logger.info(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).info(anyString, any[Object])
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.info(*, any[Object]) wasNever called
     }
   }
 
   "Calling info with a message and parameters" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      val f = fixture(_.isInfoEnabled returns true)
       import f._
       logger.info(msg, arg1)
-      verify(underlying).info(logMsg, arg1)
+      underlying.info(logMsg, arg1) was called
       logger.info(msg, arg1, arg2)
-      verify(underlying).info(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.info(logMsg, forceVarargs(arg1, arg2): _*) was called
       logger.info(msg, arg1, arg2, arg3)
-      verify(underlying).info(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
-      verify(canLogCorrelationId, times(3)).afterLog(correlationId)
+      underlying.info(logMsg, arg1, arg2, arg3) was called
+      canLogCorrelationId.logMessage(msg, correlationId) wasCalled threeTimes
+      canLogCorrelationId.afterLog(correlationId) wasCalled threeTimes
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled returns false)
       import f._
       logger.info(msg, arg1)
-      verify(underlying, never).info(logMsg, arg1)
+      underlying.info(logMsg, arg1) wasNever called
       logger.info(msg, arg1, arg2)
-      verify(underlying, never).info(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.info(logMsg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.info(msg, arg1, arg2, arg3)
-      verify(underlying, never).info(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
+      underlying.info(logMsg, arg1, arg2, arg3) wasNever called
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
     }
   }
 
@@ -234,71 +236,71 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
   "Calling debug with a message" should {
 
     "call the underlying logger's debug method if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(msg)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).debug(logMsg)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.debug(logMsg) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled returns false)
       import f._
       logger.debug(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).debug(anyString)
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.debug(*) wasNever called
     }
   }
 
   "Calling debug with a message and cause" should {
 
     "call the underlying logger's debug method if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(msg, cause)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).debug(logMsg, cause)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.debug(logMsg, cause) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled returns false)
       import f._
       logger.debug(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).debug(anyString, any[Object])
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.debug(*, any[Object]) wasNever called
     }
   }
 
   "Calling debug with a message and parameters" should {
 
     "call the underlying logger's debug method if the debug level is enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = true)
+      val f = fixture(_.isDebugEnabled returns true)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying).debug(logMsg, arg1)
+      underlying.debug(logMsg, arg1) was called
       logger.debug(msg, arg1, arg2)
-      verify(underlying).debug(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.debug(logMsg, forceVarargs(arg1, arg2): _*) was called
       logger.debug(msg, arg1, arg2, arg3)
-      verify(underlying).debug(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
-      verify(canLogCorrelationId, times(3)).afterLog(correlationId)
+      underlying.debug(logMsg, arg1, arg2, arg3) was called
+      canLogCorrelationId.logMessage(msg, correlationId) wasCalled threeTimes
+      canLogCorrelationId.afterLog(correlationId) wasCalled threeTimes
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled returns false)
       import f._
       logger.debug(msg, arg1)
-      verify(underlying, never).debug(logMsg, arg1)
+      underlying.debug(logMsg, arg1) wasNever called
       logger.debug(msg, arg1, arg2)
-      verify(underlying, never).debug(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.debug(logMsg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.debug(msg, arg1, arg2, arg3)
-      verify(underlying, never).debug(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
+      underlying.debug(logMsg, arg1, arg2, arg3) wasNever called
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
     }
   }
 
@@ -307,78 +309,79 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
   "Calling trace with a message" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(msg)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).trace(logMsg)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.trace(logMsg) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled returns false)
       import f._
       logger.trace(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).trace(anyString)
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.trace(*) wasNever called
     }
   }
 
   "Calling trace with a message and cause" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(msg, cause)
-      verify(canLogCorrelationId).logMessage(msg, correlationId)
-      verify(canLogCorrelationId).afterLog(correlationId)
-      verify(underlying).trace(logMsg, cause)
+      canLogCorrelationId.logMessage(msg, correlationId) was called
+      canLogCorrelationId.afterLog(correlationId) was called
+      underlying.trace(logMsg, cause) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled returns false)
       import f._
       logger.trace(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).trace(anyString, any[Object])
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
+      underlying.trace(*, any[Object]) wasNever called
     }
   }
 
   "Calling trace with a message and parameters" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = true)
+      val f = fixture(_.isTraceEnabled returns true)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying).trace(logMsg, arg1)
+      underlying.trace(logMsg, arg1) was called
       logger.trace(msg, arg1, arg2)
-      verify(underlying).trace(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.trace(logMsg, forceVarargs(arg1, arg2): _*) was called
       logger.trace(msg, arg1, arg2, arg3)
-      verify(underlying).trace(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, times(3)).logMessage(msg, correlationId)
-      verify(canLogCorrelationId, times(3)).afterLog(correlationId)
+      underlying.trace(logMsg, arg1, arg2, arg3) was called
+      canLogCorrelationId.logMessage(msg, correlationId) wasCalled threeTimes
+      canLogCorrelationId.afterLog(correlationId) wasCalled threeTimes
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled returns false)
       import f._
       logger.trace(msg, arg1)
-      verify(underlying, never).trace(logMsg, arg1)
+      underlying.trace(logMsg, arg1) wasNever called
       logger.trace(msg, arg1, arg2)
-      verify(underlying, never).trace(logMsg, forceVarargs(arg1, arg2): _*)
+      underlying.trace(logMsg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.trace(msg, arg1, arg2, arg3)
-      verify(underlying, never).trace(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
-      verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
+      underlying.trace(logMsg, arg1, arg2, arg3) wasNever called
+      canLogCorrelationId.logMessage(*, *) wasNever called
+      canLogCorrelationId.afterLog(*) wasNever called
     }
   }
 
-  def fixture(p: Underlying => Boolean, isEnabled: Boolean) =
+  def fixture(p: Underlying => Unit) =
     new {
       implicit val correlationId = CorrelationId("corrId")
-      implicit val canLogCorrelationId = mock[CanLog[CorrelationId]]
+      implicit val canLogCorrelationId =
+        mock[CanLog[CorrelationId]](withSettings.lenient())
       val msg = "msg"
       val cause = new RuntimeException("cause")
       val arg1 = "arg1"
@@ -386,8 +389,8 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val arg3 = "arg3"
       val logMsg = "corrId - msg"
       val underlying = mock[org.slf4j.Logger]
-      when(p(underlying)).thenReturn(isEnabled)
-      when(canLogCorrelationId.logMessage(anyString(), any[CorrelationId])).thenReturn(logMsg)
+      p(underlying)
+      canLogCorrelationId.logMessage(*, *) returns logMsg
       val logger = Logger.takingImplicit[CorrelationId](underlying)
     }
 }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -17,12 +17,10 @@
 package com.typesafe.scalalogging
 
 import java.util.NoSuchElementException
-import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
-import org.slf4j.{ Logger => Underlying }
-import org.slf4j.Marker
+
+import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.{ Matchers, WordSpec }
-import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.{ Marker, Logger => Underlying }
 
 object DummyMarker extends Marker {
   def add(childMarker: Marker): Unit = {}
@@ -39,7 +37,11 @@ object DummyMarker extends Marker {
   def remove(child: Marker): Boolean = false
 }
 
-class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
+class LoggerWithMarkerSpec
+  extends WordSpec
+  with Matchers
+  with IdiomaticMockito
+  with Varargs {
 
   // Error
 
@@ -49,21 +51,21 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(marker, msg)
-      verify(underlying).error(marker, msg)
+      underlying.error(marker, msg) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(marker, msg)
-      verify(underlying, never).error(refEq(DummyMarker), anyString)
+      underlying.error(DummyMarker, *) wasNever called
     }
 
     "call the underlying logger's error method if the error level is enabled and string is interpolated" in {
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(marker, s"msg $arg1 $arg2 $arg3")
-      verify(underlying).error(marker, "msg {} {} {}", arg1, arg2, arg3)
+      underlying.error(marker, "msg {} {} {}", arg1, arg2, arg3) was called
     }
   }
 
@@ -73,14 +75,14 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(marker, msg, cause)
-      verify(underlying).error(marker, msg, cause)
+      underlying.error(marker, msg, cause) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(marker, msg, cause)
-      verify(underlying, never).error(refEq(DummyMarker), anyString, any[Object])
+      underlying.error(DummyMarker, *, *) wasNever called
     }
   }
 
@@ -90,22 +92,22 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isErrorEnabled, isEnabled = true)
       import f._
       logger.error(marker, msg, arg1)
-      verify(underlying).error(marker, msg, arg1)
+      underlying.error(marker, msg, arg1) was called
       logger.error(marker, msg, arg1, arg2)
-      verify(underlying).error(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.error(marker, msg, forceVarargs(arg1, arg2): _*) was called
       logger.error(marker, msg, arg1, arg2, arg3)
-      verify(underlying).error(marker, msg, arg1, arg2, arg3)
+      underlying.error(marker, msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(marker, msg, arg1)
-      verify(underlying, never).error(marker, msg, arg1)
+      underlying.error(marker, msg, arg1) wasNever called
       logger.error(marker, msg, arg1, arg2)
-      verify(underlying, never).error(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.error(marker, msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.error(marker, msg, arg1, arg2, arg3)
-      verify(underlying, never).error(marker, msg, arg1, arg2, arg3)
+      underlying.error(marker, msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -117,21 +119,21 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(marker, msg)
-      verify(underlying).warn(marker, msg)
+      underlying.warn(marker, msg) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(marker, msg)
-      verify(underlying, never).warn(refEq(DummyMarker), anyString)
+      underlying.warn(DummyMarker, *) wasNever called
     }
 
     "call the underlying logger's warn method if the warn level is enabled and string is interpolated" in {
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(marker, s"msg $arg1 $arg2 $arg3")
-      verify(underlying).warn(marker, "msg {} {} {}", arg1, arg2, arg3)
+      underlying.warn(marker, "msg {} {} {}", arg1, arg2, arg3) was called
     }
   }
 
@@ -141,14 +143,14 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(marker, msg, cause)
-      verify(underlying).warn(marker, msg, cause)
+      underlying.warn(marker, msg, cause) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(marker, msg, cause)
-      verify(underlying, never).warn(refEq(DummyMarker), anyString, any[Object])
+      underlying.warn(DummyMarker, *, *) wasNever called
     }
   }
 
@@ -158,22 +160,22 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isWarnEnabled, isEnabled = true)
       import f._
       logger.warn(marker, msg, arg1)
-      verify(underlying).warn(marker, msg, arg1)
+      underlying.warn(marker, msg, arg1) was called
       logger.warn(marker, msg, arg1, arg2)
-      verify(underlying).warn(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.warn(marker, msg, forceVarargs(arg1, arg2): _*) was called
       logger.warn(marker, msg, arg1, arg2, arg3)
-      verify(underlying).warn(marker, msg, arg1, arg2, arg3)
+      underlying.warn(marker, msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(marker, msg, arg1)
-      verify(underlying, never).warn(marker, msg, arg1)
+      underlying.warn(marker, msg, arg1) wasNever called
       logger.warn(marker, msg, arg1, arg2)
-      verify(underlying, never).warn(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.warn(marker, msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.warn(marker, msg, arg1, arg2, arg3)
-      verify(underlying, never).warn(marker, msg, arg1, arg2, arg3)
+      underlying.warn(marker, msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -185,21 +187,21 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(marker, msg)
-      verify(underlying).info(marker, msg)
+      underlying.info(marker, msg) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(marker, msg)
-      verify(underlying, never).info(refEq(DummyMarker), anyString)
+      underlying.info(DummyMarker, *) wasNever called
     }
 
     "call the underlying logger's info method if the info level is enabled and string is interpolated" in {
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(marker, s"msg $arg1 $arg2 $arg3")
-      verify(underlying).info(marker, "msg {} {} {}", arg1, arg2, arg3)
+      underlying.info(marker, "msg {} {} {}", arg1, arg2, arg3) was called
     }
   }
 
@@ -209,14 +211,14 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(marker, msg, cause)
-      verify(underlying).info(marker, msg, cause)
+      underlying.info(marker, msg, cause) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(marker, msg, cause)
-      verify(underlying, never).info(refEq(DummyMarker), anyString, any[Object])
+      underlying.info(DummyMarker, *, *) wasNever called
     }
   }
 
@@ -226,22 +228,22 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isInfoEnabled, isEnabled = true)
       import f._
       logger.info(marker, msg, arg1)
-      verify(underlying).info(marker, msg, arg1)
+      underlying.info(marker, msg, arg1) was called
       logger.info(marker, msg, arg1, arg2)
-      verify(underlying).info(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.info(marker, msg, forceVarargs(arg1, arg2): _*) was called
       logger.info(marker, msg, arg1, arg2, arg3)
-      verify(underlying).info(marker, msg, arg1, arg2, arg3)
+      underlying.info(marker, msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(marker, msg, arg1)
-      verify(underlying, never).info(marker, msg, arg1)
+      underlying.info(marker, msg, arg1) wasNever called
       logger.info(marker, msg, arg1, arg2)
-      verify(underlying, never).info(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.info(marker, msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.info(marker, msg, arg1, arg2, arg3)
-      verify(underlying, never).info(marker, msg, arg1, arg2, arg3)
+      underlying.info(marker, msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -253,21 +255,21 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(marker, msg)
-      verify(underlying).debug(marker, msg)
+      underlying.debug(marker, msg) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(marker, msg)
-      verify(underlying, never).debug(refEq(DummyMarker), anyString)
+      underlying.debug(DummyMarker, *) wasNever called
     }
 
     "call the underlying logger's debug method if the debug level is enabled and string is interpolated" in {
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(marker, s"msg $arg1 $arg2 $arg3")
-      verify(underlying).debug(marker, "msg {} {} {}", arg1, arg2, arg3)
+      underlying.debug(marker, "msg {} {} {}", arg1, arg2, arg3) was called
     }
   }
 
@@ -277,14 +279,14 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(marker, msg, cause)
-      verify(underlying).debug(marker, msg, cause)
+      underlying.debug(marker, msg, cause) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(marker, msg, cause)
-      verify(underlying, never).debug(refEq(DummyMarker), anyString, any[Object])
+      underlying.debug(DummyMarker, *, *) wasNever called
     }
   }
 
@@ -294,22 +296,22 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isDebugEnabled, isEnabled = true)
       import f._
       logger.debug(marker, msg, arg1)
-      verify(underlying).debug(marker, msg, arg1)
+      underlying.debug(marker, msg, arg1) was called
       logger.debug(marker, msg, arg1, arg2)
-      verify(underlying).debug(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.debug(marker, msg, forceVarargs(arg1, arg2): _*) was called
       logger.debug(marker, msg, arg1, arg2, arg3)
-      verify(underlying).debug(marker, msg, arg1, arg2, arg3)
+      underlying.debug(marker, msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(marker, msg, arg1)
-      verify(underlying, never).debug(marker, msg, arg1)
+      underlying.debug(marker, msg, arg1) wasNever called
       logger.debug(marker, msg, arg1, arg2)
-      verify(underlying, never).debug(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.debug(marker, msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.debug(marker, msg, arg1, arg2, arg3)
-      verify(underlying, never).debug(marker, msg, arg1, arg2, arg3)
+      underlying.debug(marker, msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -321,21 +323,21 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(marker, msg)
-      verify(underlying).trace(marker, msg)
+      underlying.trace(marker, msg) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(marker, msg)
-      verify(underlying, never).trace(refEq(DummyMarker), anyString)
+      underlying.trace(DummyMarker, *) wasNever called
     }
 
     "call the underlying logger's trace method if the trace level is enabled and string is interpolated" in {
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(marker, s"msg $arg1 $arg2 $arg3")
-      verify(underlying).trace(marker, "msg {} {} {}", arg1, arg2, arg3)
+      underlying.trace(marker, "msg {} {} {}", arg1, arg2, arg3) was called
     }
   }
 
@@ -345,14 +347,14 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(marker, msg, cause)
-      verify(underlying).trace(marker, msg, cause)
+      underlying.trace(marker, msg, cause) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(marker, msg, cause)
-      verify(underlying, never).trace(refEq(DummyMarker), anyString, any[Object])
+      underlying.trace(DummyMarker, *, *) wasNever called
     }
   }
 
@@ -362,22 +364,22 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val f = fixture(_.isTraceEnabled, isEnabled = true)
       import f._
       logger.trace(marker, msg, arg1)
-      verify(underlying).trace(marker, msg, arg1)
+      underlying.trace(marker, msg, arg1) was called
       logger.trace(marker, msg, arg1, arg2)
-      verify(underlying).trace(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.trace(marker, msg, forceVarargs(arg1, arg2): _*) was called
       logger.trace(marker, msg, arg1, arg2, arg3)
-      verify(underlying).trace(marker, msg, arg1, arg2, arg3)
+      underlying.trace(marker, msg, arg1, arg2, arg3) was called
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(marker, msg, arg1)
-      verify(underlying, never).trace(marker, msg, arg1)
+      underlying.trace(marker, msg, arg1) wasNever called
       logger.trace(marker, msg, arg1, arg2)
-      verify(underlying, never).trace(marker, msg, forceVarargs(arg1, arg2): _*)
+      underlying.trace(marker, msg, forceVarargs(arg1, arg2): _*) wasNever called
       logger.trace(marker, msg, arg1, arg2, arg3)
-      verify(underlying, never).trace(marker, msg, arg1, arg2, arg3)
+      underlying.trace(marker, msg, arg1, arg2, arg3) wasNever called
     }
   }
 
@@ -390,7 +392,7 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val arg2 = new Integer(1)
       val arg3 = "arg3"
       val underlying = mock[org.slf4j.Logger]
-      when(p(underlying)(marker)).thenReturn(isEnabled)
+      p(underlying)(marker) returns isEnabled
       val logger = Logger(underlying)
     }
 }


### PR DESCRIPTION
mockito-scala make tests easier to read and strict mode to prevent any call to the underlying logger slipping under the radar