### PR TITLE
Enable -Ywarn-unused + code cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ scalacOptions ++= List(
   "-unchecked",
   "-deprecation",
   "-language:_",
-  "-encoding", "UTF-8"
+  "-encoding", "UTF-8",
+  "-Ywarn-unused"
 )
 
 osgiSettings

--- a/src/main/scala/com/typesafe/scalalogging/Logger.scala
+++ b/src/main/scala/com/typesafe/scalalogging/Logger.scala
@@ -17,7 +17,6 @@
 package com.typesafe.scalalogging
 
 import org.slf4j.{ LoggerFactory, Marker, Logger => Underlying }
-import scala.language.experimental.macros
 import scala.reflect.ClassTag
 
 /**

--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -19,7 +19,7 @@ package com.typesafe.scalalogging
 import org.slf4j.Marker
 import scala.reflect.macros.blackbox
 
-private object LoggerMacro {
+private[scalalogging] object LoggerMacro {
 
   type LoggerContext = blackbox.Context { type PrefixType = Logger }
 

--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -295,7 +295,7 @@ private[scalalogging] object LoggerMacro {
       case q"scala.StringContext.apply(..$parts).s(..$args)" =>
         val format = parts.iterator.map({ case Literal(Constant(str: String)) => str })
           // Emulate standard interpolator escaping
-          .map(StringContext.treatEscapes)
+          .map(StringContext.processEscapes)
           // Escape literal slf4j format anchors if the resulting call will require a format string
           .map(str => if (args.nonEmpty) str.replace("{}", "\\{}") else str)
           .mkString("{}")

--- a/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicit.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicit.scala
@@ -5,7 +5,9 @@ import scala.language.experimental.macros
 
 trait CanLog[A] {
   def logMessage(originalMsg: String, a: A): String
-  def afterLog(a: A): Unit = ()
+  def afterLog(a: A): Unit = {
+    val _ = a
+  }
 }
 
 @SerialVersionUID(957385465L)

--- a/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicit.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicit.scala
@@ -1,7 +1,6 @@
 package com.typesafe.scalalogging
 
 import org.slf4j.{ Marker, Logger => Underlying }
-import scala.language.experimental.macros
 
 trait CanLog[A] {
   def logMessage(originalMsg: String, a: A): String

--- a/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
@@ -3,7 +3,7 @@ package com.typesafe.scalalogging
 import org.slf4j.Marker
 import scala.reflect.macros.blackbox
 
-private object LoggerTakingImplicitMacro {
+private[scalalogging] object LoggerTakingImplicitMacro {
 
   type LoggerContext[A] = blackbox.Context { type PrefixType = LoggerTakingImplicit[A] }
 


### PR DESCRIPTION
This PR enables the `-Ywarn-unused` compiler flag and performs some cleanup with the additional warnings. There is 1 warning that I am unable to resolve, and I'll open an issue about this.