### PR TITLE
Travis: Use newer builders (fix openjdk11 build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: scala
 scala:
-   - 2.12.11
-   - 2.11.12
-   - 2.13.1
-env:
-- JDK=oraclejdk8
-- JDK=openjdk8
-- JDK=openjdk11
-before_script:
-  - jdk_switcher use $JDK
+  - 2.12.11
+  - 2.11.12
+  - 2.13.1
+jdk:
+  - oraclejdk8
+  - openjdk8
+  - openjdk11
 script:
-- sbt "++ ${TRAVIS_SCALA_VERSION}!" test
-- git diff --exit-code # check scalariform
+  - sbt "++ ${TRAVIS_SCALA_VERSION}!" test
+  - git diff --exit-code # check scalariform


### PR DESCRIPTION
https://github.com/lightbend/scala-logging/pull/176 does not seem to work since 
OpenJDK 11 is not installed on these workers: https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images
jdk_switcher does not have it aliased: https://github.com/michaelklishin/jdk_switcher#jdk-aliases

Newer workers like bionic has more installed: https://docs.travis-ci.com/user/reference/bionic/#jvm-clojure-groovy-java-scala-support