### PR TITLE
Travis fix for jdk11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ target/
 # IntelliJ
 .idea/
 
+# VSCode
+.bloop/
+.metals/
+project/metals.sbt
+
 # ENSIME
 .ensime
 .ensime_lucene/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 sudo: required
 dist: trusty
+
 language: scala
 scala:
    - 2.12.11
    - 2.11.12
    - 2.13.1
+
 jdk:
   - oraclejdk8
   - openjdk8
   - openjdk11
+
 script:
 - sbt "++ ${TRAVIS_SCALA_VERSION}!" test
 - git diff --exit-code # check scalariform
+
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt/boot/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ scala:
    - 2.12.11
    - 2.11.12
    - 2.13.1
-env:
-- JDK=oraclejdk8
-- JDK=openjdk8
-- JDK=openjdk11
-before_script:
-  - jdk_switcher use $JDK
+jdk:
+  - oraclejdk8
+  - openjdk8
+  - openjdk11
 script:
 - sbt "++ ${TRAVIS_SCALA_VERSION}!" test
 - git diff --exit-code # check scalariform

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: trusty
+dist: bionic
 
 language: scala
 scala:
@@ -8,7 +7,7 @@ scala:
    - 2.13.1
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
   - openjdk8
   - openjdk11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ dist: bionic
 
 language: scala
 scala:
-   - 2.12.11
+   - 2.12.12
    - 2.11.12
-   - 2.13.1
+   - 2.13.3
 
 jdk:
   - oraclejdk11

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Version {
   val logback   = "1.2.3"
-  val mockito   = "1.5.17"
+  val mockito   = "1.5.18"
   val scala     = "2.13.3"
   val crossScala = List(scala, "2.11.12", "2.12.12")
   val scalaTest = "3.0.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Version {
   val logback   = "1.2.3"
   val mockito   = "1.5.18"
-  val scala     = "2.13.3"
+  val scala     = "2.13.1"
   val crossScala = List(scala, "2.11.12", "2.12.12")
   val scalaTest = "3.2.1"
   val slf4j     = "1.7.30"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Version {
   val logback   = "1.2.3"
   val mockito   = "1.5.17"
-  val scala     = "2.12.11"
-  val crossScala = List(scala, "2.11.12", "2.13.1")
+  val scala     = "2.13.3"
+  val crossScala = List(scala, "2.11.12", "2.12.12")
   val scalaTest = "3.0.8"
   val slf4j     = "1.7.30"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Version {
   val mockito   = "1.5.18"
   val scala     = "2.13.3"
   val crossScala = List(scala, "2.11.12", "2.12.12")
-  val scalaTest = "3.0.8"
+  val scalaTest = "3.2.1"
   val slf4j     = "1.7.30"
 }
 

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -595,7 +595,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
       val msg = "msg"
       val cause = new RuntimeException("cause")
       val arg1 = "arg1"
-      val arg2 = new Integer(1)
+      val arg2 = Integer.valueOf(1)
       val arg3 = "arg3"
       val arg4 = 4
       val arg4ref = arg4.asInstanceOf[AnyRef]

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -21,8 +21,8 @@ import java.io._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.slf4j.{ Logger => Underlying }
-import org.scalatest.{ Matchers, WordSpec }
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 trait Varargs {
   // TODO: we used to wrap in List(...): _*, which I assume was to force the varags method to be chosen.
@@ -30,7 +30,7 @@ trait Varargs {
   def forceVarargs[T](xs: T*): scala.Seq[T] = scala.Seq(xs: _*)
 }
 
-class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
+class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
 
   // Error
 
@@ -603,7 +603,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
       val arg5ref = arg5.asInstanceOf[AnyRef]
       val arg6 = 6L
       val arg6ref = arg6.asInstanceOf[AnyRef]
-      val underlying = mock[org.slf4j.Logger]
+      val underlying = mock(classOf[org.slf4j.Logger])
       when(p(underlying)).thenReturn(isEnabled)
       val logger = Logger(underlying)
     }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
@@ -382,7 +382,7 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
       val msg = "msg"
       val cause = new RuntimeException("cause")
       val arg1 = "arg1"
-      val arg2 = new Integer(1)
+      val arg2 = Integer.valueOf(1)
       val arg3 = "arg3"
       val logMsg = "corrId - msg"
       val underlying = mock[org.slf4j.Logger]

--- a/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
@@ -2,11 +2,11 @@ package com.typesafe.scalalogging
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{ Matchers, WordSpec }
 import org.slf4j.{ Logger => Underlying }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
+class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
 
   case class CorrelationId(value: String)
 
@@ -378,14 +378,14 @@ class LoggerTakingImplicitSpec extends WordSpec with Matchers with MockitoSugar 
   def fixture(p: Underlying => Boolean, isEnabled: Boolean) =
     new {
       implicit val correlationId = CorrelationId("corrId")
-      implicit val canLogCorrelationId = mock[CanLog[CorrelationId]]
+      implicit val canLogCorrelationId = mock(classOf[CanLog[CorrelationId]])
       val msg = "msg"
       val cause = new RuntimeException("cause")
       val arg1 = "arg1"
       val arg2 = Integer.valueOf(1)
       val arg3 = "arg3"
       val logMsg = "corrId - msg"
-      val underlying = mock[org.slf4j.Logger]
+      val underlying = mock(classOf[org.slf4j.Logger])
       when(p(underlying)).thenReturn(isEnabled)
       when(canLogCorrelationId.logMessage(anyString(), any[CorrelationId])).thenReturn(logMsg)
       val logger = Logger.takingImplicit[CorrelationId](underlying)

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -21,8 +21,8 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.slf4j.{ Logger => Underlying }
 import org.slf4j.Marker
-import org.scalatest.{ Matchers, WordSpec }
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 object DummyMarker extends Marker {
   def add(childMarker: Marker): Unit = {}
@@ -39,7 +39,7 @@ object DummyMarker extends Marker {
   def remove(child: Marker): Boolean = false
 }
 
-class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with Varargs {
+class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
 
   // Error
 
@@ -389,7 +389,7 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val arg1 = "arg1"
       val arg2 = Integer.valueOf(1)
       val arg3 = "arg3"
-      val underlying = mock[org.slf4j.Logger]
+      val underlying = mock(classOf[org.slf4j.Logger])
       when(p(underlying)(marker)).thenReturn(isEnabled)
       val logger = Logger(underlying)
     }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -387,7 +387,7 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar with
       val msg = "msg"
       val cause = new RuntimeException("cause")
       val arg1 = "arg1"
-      val arg2 = new Integer(1)
+      val arg2 = Integer.valueOf(1)
       val arg3 = "arg3"
       val underlying = mock[org.slf4j.Logger]
       when(p(underlying)(marker)).thenReturn(isEnabled)

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithTaggedArgsSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithTaggedArgsSpec.scala
@@ -1,10 +1,9 @@
 package com.typesafe.scalalogging
 
-import org.scalatest.{ Matchers, WordSpec }
-
 import org.slf4j.{ Logger => Underlying }
-import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 object tag {
 
@@ -18,7 +17,7 @@ object tag {
   }
 }
 
-class LoggerWithTaggedAargsSpec extends WordSpec with MockitoSugar with Matchers with Varargs {
+class LoggerWithTaggedAargsSpec extends AnyWordSpec with Matchers with Varargs {
 
   trait Tag
 
@@ -102,7 +101,7 @@ class LoggerWithTaggedAargsSpec extends WordSpec with MockitoSugar with Matchers
     new {
       val arg1 = tag[Tag][String]("arg1")
       val arg2 = tag[Tag][Integer](Integer.valueOf(1))
-      val underlying = mock[org.slf4j.Logger]
+      val underlying = mock(classOf[org.slf4j.Logger])
       when(p(underlying)).thenReturn(isEnabled)
       val logger = Logger(underlying)
     }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithTaggedArgsSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithTaggedArgsSpec.scala
@@ -2,10 +2,8 @@ package com.typesafe.scalalogging
 
 import org.scalatest.{ Matchers, WordSpec }
 
-import java.lang.ClassCastException
 import org.slf4j.{ Logger => Underlying }
 import org.scalatestplus.mockito.MockitoSugar
-import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
 object tag {
@@ -23,8 +21,6 @@ object tag {
 class LoggerWithTaggedAargsSpec extends WordSpec with MockitoSugar with Matchers with Varargs {
 
   trait Tag
-
-  import tag._
 
   "Calling error with tagged args" should {
 


### PR DESCRIPTION
Setup jdk taken from travis docs:
https://docs.travis-ci.com/user/languages/java/#using-java-10-and-late

Similar to(fix openjdk 11): https://github.com/lightbend/scala-logging/pull/228
Also contains(mockito-scala 1.5.18): https://github.com/lightbend/scala-logging/pull/188
Also contains(scalatest 3.2.0): https://github.com/lightbend/scala-logging/pull/222
Also contains(scalatest 3.2.1): https://github.com/lightbend/scala-logging/pull/226

Bumping scala 2.13.1 -> 2.13.3 causes jvm panic for oraclejdk11 that's why it is not included here.
2.13.3 works locally okay for me with oraclejdk11, maybe travis uses older version with some kind of bug?
Anyway just worth to mention it somewhere.

Anyone could take a look at this PR? It is mainly maintenance work and maybe groundwork for PR dotty support? Would love to see that merged :D

/cc @sullis

All checks passed 💪 