### PR TITLE
Use mockito-scala-scalatest to enable strict mocks on all tests.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,11 +10,11 @@ object Version {
 }
 
 object Library {
-  val logbackClassic                     = "ch.qos.logback" %  "logback-classic" % Version.logback
-  val mockitoScala                       = "org.mockito"    %% "mockito-scala"   % Version.mockito
-  def scalaReflect(scalaVersion: String) = "org.scala-lang" %  "scala-reflect"   % scalaVersion
-  val scalaTest                          = "org.scalatest"  %% "scalatest"       % Version.scalaTest
-  val slf4jApi                           = "org.slf4j"      %  "slf4j-api"       % Version.slf4j
+  val logbackClassic                     = "ch.qos.logback" %  "logback-classic"         % Version.logback
+  val mockitoScala                       = "org.mockito"    %% "mockito-scala-scalatest" % Version.mockito
+  def scalaReflect(scalaVersion: String) = "org.scala-lang" %  "scala-reflect"           % scalaVersion
+  val scalaTest                          = "org.scalatest"  %% "scalatest"               % Version.scalaTest
+  val slf4jApi                           = "org.slf4j"      %  "slf4j-api"               % Version.slf4j
 }
 
 object Dependencies {

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -1,9 +1,8 @@
 package com.typesafe.scalalogging
 
-import java.io._
+import org.mockito.scalatest.MockitoSugar
 
-import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
+import java.io._
 import org.slf4j.{ Logger => Underlying }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -14,7 +13,7 @@ trait Varargs {
   def forceVarargs[T](xs: T*): scala.Seq[T] = scala.Seq(xs: _*)
 }
 
-class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
+class LoggerSpec extends AnyWordSpec with Matchers with Varargs with MockitoSugar {
 
   // Error
 
@@ -31,7 +30,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(msg)
-      verify(underlying, never).error(anyString)
+      verify(underlying, never).error(any[String])
     }
   }
 
@@ -66,7 +65,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(msg, cause)
-      verify(underlying, never).error(anyString, any[Object])
+      verify(underlying, never).error(any[String], any[Object])
     }
   }
 
@@ -110,7 +109,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(msg)
-      verify(underlying, never).warn(anyString)
+      verify(underlying, never).warn(any[String])
     }
   }
 
@@ -144,7 +143,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(msg, cause)
-      verify(underlying, never).warn(anyString, any[Object])
+      verify(underlying, never).warn(any[String], any[Object])
     }
   }
 
@@ -188,7 +187,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(msg)
-      verify(underlying, never).info(anyString)
+      verify(underlying, never).info(any[String])
     }
   }
 
@@ -222,7 +221,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(msg, cause)
-      verify(underlying, never).info(anyString, any[Object])
+      verify(underlying, never).info(any[String], any[Object])
     }
   }
 
@@ -266,7 +265,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(msg)
-      verify(underlying, never).debug(anyString)
+      verify(underlying, never).debug(any[String])
     }
   }
   "Calling debug with an interpolated message" should {
@@ -299,7 +298,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(msg, cause)
-      verify(underlying, never).debug(anyString, any[Object])
+      verify(underlying, never).debug(any[String], any[Object])
     }
   }
 
@@ -343,7 +342,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(msg)
-      verify(underlying, never).trace(anyString)
+      verify(underlying, never).trace(any[String])
     }
   }
 
@@ -377,7 +376,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(msg, cause)
-      verify(underlying, never).trace(anyString, any[Object])
+      verify(underlying, never).trace(any[String], any[Object])
     }
   }
 
@@ -587,7 +586,7 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs {
       val arg5ref = arg5.asInstanceOf[AnyRef]
       val arg6 = 6L
       val arg6ref = arg6.asInstanceOf[AnyRef]
-      val underlying = mock(classOf[org.slf4j.Logger])
+      val underlying = mock[org.slf4j.Logger]
       when(p(underlying)).thenReturn(isEnabled)
       val logger = Logger(underlying)
     }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerTakingImplicitSpec.scala
@@ -1,12 +1,11 @@
 package com.typesafe.scalalogging
 
-import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
+import org.mockito.scalatest.MockitoSugar
 import org.slf4j.{ Logger => Underlying }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
+class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs with MockitoSugar {
 
   case class CorrelationId(value: String)
 
@@ -24,12 +23,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.error(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).error(anyString)
+      verify(underlying, never).error(any[String])
     }
   }
 
@@ -45,12 +44,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.error(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).error(anyString, any[Object])
+      verify(underlying, never).error(any[String], any[Object])
     }
   }
 
@@ -70,7 +69,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's error method if the error level is not enabled" in {
-      val f = fixture(_.isErrorEnabled, isEnabled = false)
+      val f = fixture(_.isErrorEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.error(msg, arg1)
       verify(underlying, never).error(logMsg, arg1)
@@ -78,7 +77,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
       verify(underlying, never).error(logMsg, forceVarargs(arg1, arg2): _*)
       logger.error(msg, arg1, arg2, arg3)
       verify(underlying, never).error(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
     }
   }
@@ -97,12 +96,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.warn(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).warn(anyString)
+      verify(underlying, never).warn(any[String])
     }
   }
 
@@ -118,12 +117,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.warn(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).warn(anyString, any[Object])
+      verify(underlying, never).warn(any[String], any[Object])
     }
   }
 
@@ -143,7 +142,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's warn method if the warn level is not enabled" in {
-      val f = fixture(_.isWarnEnabled, isEnabled = false)
+      val f = fixture(_.isWarnEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.warn(msg, arg1)
       verify(underlying, never).warn(logMsg, arg1)
@@ -151,7 +150,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
       verify(underlying, never).warn(logMsg, forceVarargs(arg1, arg2): _*)
       logger.warn(msg, arg1, arg2, arg3)
       verify(underlying, never).warn(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
     }
   }
@@ -170,12 +169,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.info(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).info(anyString)
+      verify(underlying, never).info(any[String])
     }
   }
 
@@ -191,12 +190,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.info(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).info(anyString, any[Object])
+      verify(underlying, never).info(any[String], any[Object])
     }
   }
 
@@ -216,7 +215,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's info method if the info level is not enabled" in {
-      val f = fixture(_.isInfoEnabled, isEnabled = false)
+      val f = fixture(_.isInfoEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.info(msg, arg1)
       verify(underlying, never).info(logMsg, arg1)
@@ -224,7 +223,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
       verify(underlying, never).info(logMsg, forceVarargs(arg1, arg2): _*)
       logger.info(msg, arg1, arg2, arg3)
       verify(underlying, never).info(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
     }
   }
@@ -243,12 +242,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.debug(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).debug(anyString)
+      verify(underlying, never).debug(any[String])
     }
   }
 
@@ -264,12 +263,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.debug(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).debug(anyString, any[Object])
+      verify(underlying, never).debug(any[String], any[Object])
     }
   }
 
@@ -289,7 +288,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's debug method if the debug level is not enabled" in {
-      val f = fixture(_.isDebugEnabled, isEnabled = false)
+      val f = fixture(_.isDebugEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.debug(msg, arg1)
       verify(underlying, never).debug(logMsg, arg1)
@@ -297,7 +296,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
       verify(underlying, never).debug(logMsg, forceVarargs(arg1, arg2): _*)
       logger.debug(msg, arg1, arg2, arg3)
       verify(underlying, never).debug(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
     }
   }
@@ -316,12 +315,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.trace(msg)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).trace(anyString)
+      verify(underlying, never).trace(any[String])
     }
   }
 
@@ -337,12 +336,12 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.trace(msg, cause)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
-      verify(underlying, never).trace(anyString, any[Object])
+      verify(underlying, never).trace(any[String], any[Object])
     }
   }
 
@@ -362,7 +361,7 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
     }
 
     "not call the underlying logger's trace method if the trace level is not enabled" in {
-      val f = fixture(_.isTraceEnabled, isEnabled = false)
+      val f = fixture(_.isTraceEnabled, isEnabled = false, stubCanLog = false)
       import f._
       logger.trace(msg, arg1)
       verify(underlying, never).trace(logMsg, arg1)
@@ -370,24 +369,24 @@ class LoggerTakingImplicitSpec extends AnyWordSpec with Matchers with Varargs {
       verify(underlying, never).trace(logMsg, forceVarargs(arg1, arg2): _*)
       logger.trace(msg, arg1, arg2, arg3)
       verify(underlying, never).trace(logMsg, arg1, arg2, arg3)
-      verify(canLogCorrelationId, never).logMessage(anyString, any[CorrelationId])
+      verify(canLogCorrelationId, never).logMessage(any[String], any[CorrelationId])
       verify(canLogCorrelationId, never).afterLog(any[CorrelationId])
     }
   }
 
-  def fixture(p: Underlying => Boolean, isEnabled: Boolean) =
+  def fixture(p: Underlying => Boolean, isEnabled: Boolean, stubCanLog: Boolean = true) =
     new {
       implicit val correlationId = CorrelationId("corrId")
-      implicit val canLogCorrelationId = mock(classOf[CanLog[CorrelationId]])
+      implicit val canLogCorrelationId = mock[CanLog[CorrelationId]]
       val msg = "msg"
       val cause = new RuntimeException("cause")
       val arg1 = "arg1"
       val arg2 = Integer.valueOf(1)
       val arg3 = "arg3"
       val logMsg = "corrId - msg"
-      val underlying = mock(classOf[org.slf4j.Logger])
+      val underlying = mock[org.slf4j.Logger]
       when(p(underlying)).thenReturn(isEnabled)
-      when(canLogCorrelationId.logMessage(anyString(), any[CorrelationId])).thenReturn(logMsg)
+      if (stubCanLog) when(canLogCorrelationId.logMessage(any[String], any[CorrelationId])).thenReturn(logMsg)
       val logger = Logger.takingImplicit[CorrelationId](underlying)
     }
 }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -1,8 +1,8 @@
 package com.typesafe.scalalogging
 
+import org.mockito.scalatest.MockitoSugar
+
 import java.util.NoSuchElementException
-import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
 import org.slf4j.{ Logger => Underlying }
 import org.slf4j.Marker
 import org.scalatest.matchers.should.Matchers
@@ -23,7 +23,7 @@ object DummyMarker extends Marker {
   def remove(child: Marker): Boolean = false
 }
 
-class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
+class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs with MockitoSugar {
 
   // Error
 
@@ -40,7 +40,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(marker, msg)
-      verify(underlying, never).error(refEq(DummyMarker), anyString)
+      verify(underlying, never).error(refEq(DummyMarker), any[String])
     }
 
     "call the underlying logger's error method if the error level is enabled and string is interpolated" in {
@@ -64,7 +64,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isErrorEnabled, isEnabled = false)
       import f._
       logger.error(marker, msg, cause)
-      verify(underlying, never).error(refEq(DummyMarker), anyString, any[Object])
+      verify(underlying, never).error(refEq(DummyMarker), any[String], any[Object])
     }
   }
 
@@ -108,7 +108,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(marker, msg)
-      verify(underlying, never).warn(refEq(DummyMarker), anyString)
+      verify(underlying, never).warn(refEq(DummyMarker), any[String])
     }
 
     "call the underlying logger's warn method if the warn level is enabled and string is interpolated" in {
@@ -132,7 +132,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isWarnEnabled, isEnabled = false)
       import f._
       logger.warn(marker, msg, cause)
-      verify(underlying, never).warn(refEq(DummyMarker), anyString, any[Object])
+      verify(underlying, never).warn(refEq(DummyMarker), any[String], any[Object])
     }
   }
 
@@ -176,7 +176,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(marker, msg)
-      verify(underlying, never).info(refEq(DummyMarker), anyString)
+      verify(underlying, never).info(refEq(DummyMarker), any[String])
     }
 
     "call the underlying logger's info method if the info level is enabled and string is interpolated" in {
@@ -200,7 +200,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isInfoEnabled, isEnabled = false)
       import f._
       logger.info(marker, msg, cause)
-      verify(underlying, never).info(refEq(DummyMarker), anyString, any[Object])
+      verify(underlying, never).info(refEq(DummyMarker), any[String], any[Object])
     }
   }
 
@@ -244,7 +244,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(marker, msg)
-      verify(underlying, never).debug(refEq(DummyMarker), anyString)
+      verify(underlying, never).debug(refEq(DummyMarker), any[String])
     }
 
     "call the underlying logger's debug method if the debug level is enabled and string is interpolated" in {
@@ -268,7 +268,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isDebugEnabled, isEnabled = false)
       import f._
       logger.debug(marker, msg, cause)
-      verify(underlying, never).debug(refEq(DummyMarker), anyString, any[Object])
+      verify(underlying, never).debug(refEq(DummyMarker), any[String], any[Object])
     }
   }
 
@@ -312,7 +312,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(marker, msg)
-      verify(underlying, never).trace(refEq(DummyMarker), anyString)
+      verify(underlying, never).trace(refEq(DummyMarker), any[String])
     }
 
     "call the underlying logger's trace method if the trace level is enabled and string is interpolated" in {
@@ -336,7 +336,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isTraceEnabled, isEnabled = false)
       import f._
       logger.trace(marker, msg, cause)
-      verify(underlying, never).trace(refEq(DummyMarker), anyString, any[Object])
+      verify(underlying, never).trace(refEq(DummyMarker), any[String], any[Object])
     }
   }
 
@@ -373,7 +373,7 @@ class LoggerWithMarkerSpec extends AnyWordSpec with Matchers with Varargs {
       val arg1 = "arg1"
       val arg2 = Integer.valueOf(1)
       val arg3 = "arg3"
-      val underlying = mock(classOf[org.slf4j.Logger])
+      val underlying = mock[org.slf4j.Logger]
       when(p(underlying)(marker)).thenReturn(isEnabled)
       val logger = Logger(underlying)
     }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithTaggedArgsSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithTaggedArgsSpec.scala
@@ -1,7 +1,7 @@
 package com.typesafe.scalalogging
 
+import org.mockito.scalatest.MockitoSugar
 import org.slf4j.{ Logger => Underlying }
-import org.mockito.Mockito._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -17,7 +17,7 @@ object tag {
   }
 }
 
-class LoggerWithTaggedAargsSpec extends AnyWordSpec with Matchers with Varargs {
+class LoggerWithTaggedArgsSpec extends AnyWordSpec with Matchers with Varargs with MockitoSugar {
 
   trait Tag
 
@@ -27,16 +27,18 @@ class LoggerWithTaggedAargsSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isErrorEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.error("This should not throw: {}, {}", arg1, arg2)
+        logger.error("This should not throw: {}, {} - {}", arg1, arg2, arg3)
       }
+      verify(underlying).error(any[String], *, *, *)
     }
 
     "not throw ClassCastException when interpolated message is passed" in {
       val f = fixture(_.isErrorEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.error(s"This should not throw: $arg1, $arg2")
+        logger.error(s"This should not throw: $arg1, $arg2, $arg3")
       }
+      verify(underlying).error(any[String], *, *, *)
     }
   }
 
@@ -46,35 +48,39 @@ class LoggerWithTaggedAargsSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isTraceEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.trace("This should not throw: {}, {}", arg1, arg2)
+        logger.trace("This should not throw: {}, {} - {}", arg1, arg2, arg3)
       }
+      verify(underlying).trace(any[String], *, *, *)
     }
 
     "not throw ClassCastException when interpolated message is passed" in {
       val f = fixture(_.isTraceEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.trace(s"This should not throw: $arg1, $arg2")
+        logger.trace(s"This should not throw: $arg1, $arg2, $arg3")
       }
+      verify(underlying).trace(any[String], *, *, *)
     }
   }
 
   "Calling debug with tagged args" should {
 
     "not throw ClassCastException when varargs are passed" in {
-      val f = fixture(_.isTraceEnabled)
+      val f = fixture(_.isDebugEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.debug("This should not throw: {}, {}", arg1, arg2)
+        logger.debug("This should not throw: {}, {} - {}", arg1, arg2, arg3)
       }
+      verify(underlying).debug(any[String], *, *, *)
     }
 
     "not throw ClassCastException when interpolated message is passed" in {
-      val f = fixture(_.isTraceEnabled)
+      val f = fixture(_.isDebugEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.debug(s"This should not throw: $arg1, $arg2")
+        logger.debug(s"This should not throw: $arg1, $arg2, $arg3")
       }
+      verify(underlying).debug(any[String], *, *, *)
     }
   }
 
@@ -84,16 +90,18 @@ class LoggerWithTaggedAargsSpec extends AnyWordSpec with Matchers with Varargs {
       val f = fixture(_.isInfoEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.info("This should not throw: {}, {}", arg1, arg2)
+        logger.info("This should not throw: {}, {} - {}", arg1, arg2, arg3)
       }
+      verify(underlying).info(any[String], *, *, *)
     }
 
     "not throw ClassCastException when interpolated message is passed" in {
       val f = fixture(_.isInfoEnabled)
       import f._
       noException shouldBe thrownBy {
-        logger.info(s"This should not throw: $arg1, $arg2")
+        logger.info(s"This should not throw: $arg1, $arg2, $arg3")
       }
+      verify(underlying).info(any[String], *, *, *)
     }
   }
 
@@ -101,7 +109,8 @@ class LoggerWithTaggedAargsSpec extends AnyWordSpec with Matchers with Varargs {
     new {
       val arg1 = tag[Tag][String]("arg1")
       val arg2 = tag[Tag][Integer](Integer.valueOf(1))
-      val underlying = mock(classOf[org.slf4j.Logger])
+      val arg3 = tag[Tag][Boolean](true)
+      val underlying = mock[org.slf4j.Logger]
       when(p(underlying)).thenReturn(isEnabled)
       val logger = Logger(underlying)
     }


### PR DESCRIPTION
Inspired by the comment on #172 this PR uses the ScalaTest integration of mockito-scala so all mocks are strict by default.

An easy way to verify this would be to re-write the first test on `LoggerSpec` as (notice the extra direct call to `underlying.info`

```scala
    "call the underlying logger's error method if the error level is enabled" in {
        val f = fixture(_.isErrorEnabled, isEnabled = true)
        import f._
        logger.error(msg)
        underlying.info("called by accident")
        verify(underlying).error(msg)
    }
```

Executing such test would fail as
```
Unexpected invocations found

The following invocations are unexpected (click to navigate to relevant line of code):
1. logger.info("called by accident"); -> at com.typesafe.scalalogging.LoggerSpec.$anonfun$new$2(LoggerSpec.scala:26)
Please make sure you aren't missing any stubbing or that your code actually does what you want
org.mockito.exceptions.misusing.UnexpectedInvocationException: Unexpected invocations found
```

This change has already paid by itself as it shown that the tests on `LoggerWithTaggedArgsSpec` L#68 and L#77 were not testing anything as the wrong log level was being enabled