### PR TITLE
replace sbt-release with sbt-ci-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,30 @@ import: scala/scala-dev:travis/default.yml
 language: scala
 
 scala:
-   - 2.12.13
-   - 2.11.12
-   - 2.13.4
+  - 2.11.12
+  - 2.12.13
+  - 2.13.4
 
 env:
   - ADOPTOPENJDK=8
   - ADOPTOPENJDK=11
 
+before_install:
+  - git fetch --tags
+
 script:
-- sbt "++ ${TRAVIS_SCALA_VERSION}!" test
-- git diff --exit-code # check scalariform
+  - sbt "++${TRAVIS_SCALA_VERSION}" test
+  - git diff --exit-code # check scalariform
+
+stages:
+  - name: release
+    if: (tag IS present) AND NOT fork
+
+jobs:
+  include:
+    - stage: release
+      script: sbt ci-release
+
+notifications:
+  email:
+  - seth.tisue@lightbend.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# scala-logging [![Build Status](https://travis-ci.org/lightbend/scala-logging.svg?branch=master)](https://travis-ci.org/lightbend/scala-logging)
+# scala-logging [![Build Status](https://travis-ci.com/lightbend/scala-logging.svg?branch=master)](https://travis-ci.com/lightbend/scala-logging)
 
 Scala Logging is a **convenient** and **fast** logging library wrapping [SLF4J](http://www.slf4j.org).
 
@@ -14,9 +14,9 @@ It's fast, because thanks to Scala macros the *check-enabled-idiom* is applied a
 if (logger.isDebugEnabled) logger.debug(s"Some $expensive message!")
 ```
 
-## Prerequisites ##
+## Prerequisites
 
-* Java 6 or higher
+* Java 8 or higher
 * Scala 2.11, 2.12 or 2.13
 * Logging backend compatible with SLF4J
 
@@ -28,21 +28,20 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 
 If you are looking for a version compatible with Scala 2.10, check out Scala Logging 2.x.
 
-## Getting Scala Logging ##
+## Getting Scala Logging
 
 Scala Logging is published to Sonatype OSS and Maven Central:
 
 - Group id / organization: *com.typesafe.scala-logging*
 - Artifact id / name: *scala-logging*
-- Latest version is 3.9.2
 
-Usage with SBT, adding a dependency to the latest version of Scala Logging to your sbt build definition file:
+sbt users may add this to their `build.sbt`:
 
 ```scala
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 ```
 
-## Using Scala Logging ##
+## Using Scala Logging
 
 The `Logger` class from the `com.typesafe.scalalogging` package wraps an underlying SLF4J logger.
 In order to create a `Logger`, you pass a name to the `apply` factory method defined in the `Logger` companion object:
@@ -76,7 +75,7 @@ these traits are mixed:
 ```scala
 class MyClass extends LazyLogging {
   logger.debug("This is very convenient ;-)")
-  
+
   logger.whenDebugEnabled {
     println("This would only execute when the debug level is enabled.")
     (1 to 10).foreach(x => println("Scala logging is great!"))
@@ -87,19 +86,19 @@ class MyClass extends LazyLogging {
 `LoggerTakingImplicit` provides the same methods as `Logger` class, but with additional implicit parameter `A`.
 During creation of the `LoggerTakingImplicit` evidence `CanLog[A]` is required.
 It may be useful when contextual parameter (e.g. _Correlation ID_) is being passed around and you would like to include it in the log messages:
- 
+
 ```scala
 case class CorrelationId(value: String)
 implicit case object CanLogCorrelationId extends CanLog[CorrelationId] {
   override def logMessage(originalMsg: String, a: CorrelationId): String = s"${a.value} $originalMsg"
 }
- 
-implicit val correlationId = CorrelationId("ID") 
- 
+
+implicit val correlationId = CorrelationId("ID")
+
 val logger = Logger.takingImplicit[CorrelationId]("test")
 logger.info("Test") // takes implicit correlationId and logs "ID Test"
 ```
- 
+
 It's possible to use `MDC` through `CanLog` without any troubles with execution context.
 
 ```scala
@@ -109,60 +108,26 @@ implicit case object CanLogCorrelationId extends CanLog[CorrelationId] {
     MDC.put("correlationId", a.value)
     originalMsg
   }
-  
+
   override def afterLog(a: CorrelationId): Unit = {
     MDC.remove("correlationId")
   }
 }
- 
-implicit val correlationId = CorrelationId("ID") 
- 
+
+implicit val correlationId = CorrelationId("ID")
+
 val logger = Logger.takingImplicit[CorrelationId]("test")
 
 def serviceMethod(implicit correlationId: CorrelationId): Future[Result] = {
-  dbCall.map { value => 
+  dbCall.map { value =>
     logger.trace(s"Received value $value from db") // takes implicit correlationId
     toResult(value)
   }
 }
 ```
 
-### What's new?
-
-### 3.9.2
- - Use marker inside macros in is*Enabled methods
-
-### 3.9.0
- - Functions for on demand code execution added in Logger class
-
-#### 3.8.0
- - Added LoggerTakingImplicit, bugfixes.
-
-#### 3.7.2
- - Make logger to consume args of type `Any` with slf4 interpolator.
-
-#### 3.7.1
- - Remove @volatile from lazy logger, failing with strict compiler settings
-
-##### 3.7.0
- - Deconstruct Scala's string interpolation into SLF4J string interpolation.
- 
-##### 3.6.0 - flawed release
-
-##### 3.5.0
- - More Logger factory methods, bugfixes and upgrades, published for Scala 2.12.0-M5, 2.12.0-RC1, 2.12.0-RC2 and 2.12.0.
-
-##### 3.4.0
- - Fixes #38 - Logger.info() cannot be used with primitive types.
-
-##### 3.3.0
- - Fixes #42 - Request: Add Logger(class). README changes.
-
-##### 3.2.0
- - SLF4J loggers and our Logger now survive serialization. By survive serialization, we mean that the
-   deserialized logger instances are fully functional.
-
 ## String Interpolation
+
 It is idiomatic to use Scala's string interpolation `logger.error(s"log $value")` instead of SLF4J string interpolation `logger.error("log {}", value)`.
 However there are some tools (such as [Sentry](https://sentry.io)) that use the log message format as grouping key. Therefore they do not work well with
 Scala's string interpolation.
@@ -180,6 +145,7 @@ logger.error("my log message: {} {} {}", arg1, arg2, arg3)
 This has no effect on behavior and performace should be comparable (depends on the underlying logging library).
 
 ### Limitations
+
  - Works only when string interpolation is directly used inside the logging statement. That is when the log message is static (available at compile time).
  - Works only for the `logger.<level>(message)` and `logger.<level>(marker, message)` logging methods. It does not work if you want to log an exception and
  use string interpolation too (this is a limitation of the SLF4J API).
@@ -198,10 +164,10 @@ def foo(arg: String)(implicit line: sourcecode.Line, file: sourcecode.File) = {
 foo("hello") // the implicit sourcecode.File is filled in automatically
 ```
 
-## Contribution policy ##
+## Maintenance status
 
-Contributions via GitHub pull requests are gladly accepted from their original author. Before we can accept pull requests, you will need to agree to the [Typesafe Contributor License Agreement](http://www.typesafe.com/contribute/cla) online, using your GitHub account.
+This library is community-maintained. It is not supported under the Lightbend subscription.
 
-## License ##
+## Contribution policy
 
-This code is open source software licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+Contributions via GitHub pull requests are gladly accepted from their original author. Before we can accept pull requests, you will need to agree to the [Lightbend Contributor License Agreement](https://www.lightbend.com/contribute/cla) online, using your GitHub account.

--- a/build.sbt
+++ b/build.sbt
@@ -1,51 +1,37 @@
-import com.typesafe.sbt.osgi.SbtOsgi
-import sbt._
+// basics
 
-enablePlugins(SbtOsgi)
-
-organization := "com.typesafe.scala-logging"
 name := "scala-logging"
-licenses := Seq("Apache 2.0 License" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-homepage := Some(url("https://github.com/lightbend/scala-logging"))
-incOptions := incOptions.value.withLogRecompileOnMacro(false)
-scalaVersion := Version.scala
-crossScalaVersions := Version.crossScala
-scalacOptions ++= List(
+scalacOptions ++= Seq(
   "-unchecked",
   "-deprecation",
   "-language:_",
   "-encoding", "UTF-8",
   "-Ywarn-unused"
 )
+incOptions := incOptions.value.withLogRecompileOnMacro(false)
+libraryDependencies ++= Dependencies.scalaLogging(scalaVersion.value)
+initialCommands := """|import com.typesafe.scalalogging._
+                      |import org.slf4j.{ Logger => Underlying, _ }""".stripMargin
 
+// OSGi
+
+import com.typesafe.sbt.osgi.SbtOsgi
+enablePlugins(SbtOsgi)
 osgiSettings
-
 OsgiKeys.bundleSymbolicName := "com.typesafe.scala-logging"
 OsgiKeys.privatePackage := Seq()
 OsgiKeys.exportPackage := Seq("com.typesafe.scalalogging*")
 
-releaseVersionBump := sbtrelease.Version.Bump.Minor
-releaseCrossBuild := true
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+// publishing
 
-libraryDependencies ++= Dependencies.scalaLogging(scalaVersion.value)
-
-initialCommands := """|import com.typesafe.scalalogging._
-                      |import org.slf4j.{ Logger => Underlying, _ }""".stripMargin
-
-publishTo := {
-  if (isSnapshot.value)
-    Some(Opts.resolver.sonatypeSnapshots)
-  else
-    Some(Opts.resolver.sonatypeStaging)
-}
-publishArtifact in Test := false
+organization := "com.typesafe.scala-logging"
+licenses := Seq("Apache 2.0 License" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+homepage := Some(url("https://github.com/lightbend/scala-logging"))
+Test / publishArtifact := false
 pomIncludeRepository := (_ => false)
-
 scmInfo := Some(
   ScmInfo(url("https://github.com/lightbend/scala-logging"), "scm:git:git@github.com:lightbend/scala-logging.git")
 )
-
 developers := List(
   Developer(
     id = "hseeberger",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,6 @@ import sbt._
 object Version {
   val logback   = "1.2.3"
   val mockito   = "1.16.23"
-  val scala     = "2.13.4"
-  val crossScala = List(scala, "2.11.12", "2.12.13")
   val scalaTest = "3.2.3"
   val slf4j     = "1.7.30"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,5 @@
-resolvers += Resolver.typesafeRepo("releases")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
-
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.2")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "3.9.3-SNAPSHOT"


### PR DESCRIPTION
includes adopting sbt-dynver (to set `version`) and sbt-travisci (to set `scalaVersion` and `crossScalaVersions`)

fixes #254