### PR TITLE
Update to Scala 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
   - 2.11.12
   - 2.12.13
   - 2.13.5
-  - 3.0.0-RC3
+  - 3.0.0
 env:
   - ADOPTOPENJDK=8
   - ADOPTOPENJDK=11

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Version {
   val logback   = "1.2.3"
-  val mockito   = "3.2.8.0"
-  val scalaTest = "3.2.8"
+  val mockito   = "3.2.9.0"
+  val scalaTest = "3.2.9"
   val slf4j     = "1.7.30"
 }
 


### PR DESCRIPTION
Also updates Scalatest to 3.2.9, as 3.2.8 doesn't have a 3.0.0 build.