### PR TITLE
bump Scala versions (2.12.14, 2.13.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.13
-  - 2.13.5
+  - 2.12.14
+  - 2.13.6
   - 3.0.0
 env:
   - ADOPTOPENJDK=8


### PR DESCRIPTION
(secondary purpose of this PR to make sure Travis-CI is triggering and running again; we needed to renew our Lightbend plan)