### PR TITLE
Use 3.9.4 in readme for Scala 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Scala Logging is published to Sonatype OSS and Maven Central:
 sbt users may add this to their `build.sbt`:
 
 ```scala
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.3"
+libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
 ```
 
 ## Using Scala Logging


### PR DESCRIPTION
Version 3.9.3 is only published for `3.0.0-RC1`

Whereas 3.9.4 is published for `3` which better matches the prerequisites in  the readme.

https://mvnrepository.com/artifact/com.typesafe.scala-logging/scala-logging