### PR TITLE
Fix macro when interpolated argument is `Throwable`

### DIFF
--- a/src/main/scala-2/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala-2/com/typesafe/scalalogging/LoggerMacro.scala
@@ -295,7 +295,7 @@ private[scalalogging] object LoggerMacro {
   private def formatArgs(c: LoggerContext)(args: c.Expr[Any]*) = {
     import c.universe._
     args.map { arg =>
-      c.Expr[AnyRef](if (arg.tree.tpe <:< weakTypeOf[AnyRef]) arg.tree else q"$arg.asInstanceOf[_root_.scala.AnyRef]")
+      c.Expr[AnyRef](if (arg.tree.tpe <:< weakTypeOf[AnyRef]) q"$arg: _root_.scala.AnyRef" else q"$arg.asInstanceOf[_root_.scala.AnyRef]")
     }
   }
 }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -451,6 +451,13 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs with MockitoSuga
       logger.error(s"""foo\nbar $arg1""")
       verify(underlying).error(s"""foo\nbar {}""", arg1)
     }
+
+    "call the underlying format method when interpolated argument is a Throwable" in {
+      val f = fixture(_.isErrorEnabled, isEnabled = true)
+      import f._
+      logger.error(s"""foo\nbar $arg7""")
+      verify(underlying).error(s"""foo\nbar {}""", arg7ref)
+    }
   }
 
   "Logging a message using slf4 interpolator and Any args" should {
@@ -587,6 +594,8 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs with MockitoSuga
     val arg5ref = arg5.asInstanceOf[AnyRef]
     val arg6 = 6L
     val arg6ref = arg6.asInstanceOf[AnyRef]
+    val arg7 = new Throwable
+    val arg7ref = arg7.asInstanceOf[AnyRef]
     val underlying = mock[org.slf4j.Logger]
     when(p(underlying)).thenReturn(isEnabled)
     val logger = Logger(underlying)


### PR DESCRIPTION
When passing an interpolated string with a `Throwable`, the Scala 2 macro incorrectly calls the non-format overload:
```java
public void error(String msg, Throwable t);
```

Coerce all arguments to `AnyRef` so that the format overload is used:
```java
public void error(String format, Object arg);
```
Fixes #216
Fixes #95
