### PR TITLE
Scala-3: Added the missing when***Enabled() methods in LoggerTakingImplicitImpl under scala-3 package

### DIFF
--- a/src/main/scala-2/com/typesafe/scalalogging/LoggerTakingImplicitImpl.scala
+++ b/src/main/scala-2/com/typesafe/scalalogging/LoggerTakingImplicitImpl.scala
@@ -18,6 +18,8 @@ class LoggerTakingImplicitImpl[A] private[scalalogging] {
 
   def error(marker: Marker, message: String, args: Any*)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.errorMessageArgsMarker[A]
 
+  def whenErrorEnabled(body: Unit)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.errorCode[A]
+
   // Warn
 
   def warn(message: String)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.warnMessage[A]
@@ -31,6 +33,8 @@ class LoggerTakingImplicitImpl[A] private[scalalogging] {
   def warn(marker: Marker, message: String, cause: Throwable)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.warnMessageCauseMarker[A]
 
   def warn(marker: Marker, message: String, args: Any*)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.warnMessageArgsMarker[A]
+
+  def whenWarnEnabled(body: Unit)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.warnCode[A]
 
   // Info
 
@@ -46,6 +50,8 @@ class LoggerTakingImplicitImpl[A] private[scalalogging] {
 
   def info(marker: Marker, message: String, args: Any*)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.infoMessageArgsMarker[A]
 
+  def whenInfoEnabled(body: Unit)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.infoCode[A]
+
   // Debug
 
   def debug(message: String)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.debugMessage[A]
@@ -59,6 +65,8 @@ class LoggerTakingImplicitImpl[A] private[scalalogging] {
   def debug(marker: Marker, message: String, cause: Throwable)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.debugMessageCauseMarker[A]
 
   def debug(marker: Marker, message: String, args: Any*)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.debugMessageArgsMarker[A]
+
+  def whenDebugEnabled(body: Unit)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.debugCode[A]
 
   // Trace
 
@@ -74,4 +82,5 @@ class LoggerTakingImplicitImpl[A] private[scalalogging] {
 
   def trace(marker: Marker, message: String, args: Any*)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.traceMessageArgsMarker[A]
 
+  def whenTraceEnabled(body: Unit)(implicit a: A): Unit = macro LoggerTakingImplicitMacro.traceCode[A]
 }

--- a/src/main/scala-2/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
+++ b/src/main/scala-2/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
@@ -83,6 +83,16 @@ private[scalalogging] object LoggerTakingImplicitMacro {
     }
   }
 
+  def errorCode[A](c: LoggerContext[A])(body: c.Expr[Unit])(a: c.Expr[A]): c.universe.Tree = {
+    import c.universe._
+    val underlying = q"${c.prefix}.underlying"
+    val canLogEv = q"${c.prefix}.canLogEv"
+    q"""if ($underlying.isErrorEnabled) {
+          $underlying.error($canLogEv.logMessage($body))
+          $canLogEv.afterLog($a)
+        }"""
+  }
+
   // Warn
 
   def warnMessage[A](c: LoggerContext[A])(message: c.Expr[String])(a: c.Expr[A]): c.universe.Tree = {
@@ -157,6 +167,16 @@ private[scalalogging] object LoggerTakingImplicitMacro {
           $canLogEv.afterLog($a)
         }"""
     }
+  }
+
+  def warnCode[A](c: LoggerContext[A])(body: c.Expr[Unit])(a: c.Expr[A]): c.universe.Tree = {
+    import c.universe._
+    val underlying = q"${c.prefix}.underlying"
+    val canLogEv = q"${c.prefix}.canLogEv"
+    q"""if ($underlying.isWarnEnabled) {
+          $underlying.warn($canLogEv.logMessage($body))
+          $canLogEv.afterLog($a)
+        }"""
   }
 
   // Info
@@ -235,6 +255,16 @@ private[scalalogging] object LoggerTakingImplicitMacro {
     }
   }
 
+  def infoCode[A](c: LoggerContext[A])(body: c.Expr[Unit])(a: c.Expr[A]): c.universe.Tree = {
+    import c.universe._
+    val underlying = q"${c.prefix}.underlying"
+    val canLogEv = q"${c.prefix}.canLogEv"
+    q"""if ($underlying.isInfoEnabled) {
+          $underlying.info($canLogEv.logMessage($body))
+          $canLogEv.afterLog($a)
+        }"""
+  }
+
   // Debug
 
   def debugMessage[A](c: LoggerContext[A])(message: c.Expr[String])(a: c.Expr[A]): c.universe.Tree = {
@@ -311,6 +341,17 @@ private[scalalogging] object LoggerTakingImplicitMacro {
     }
   }
 
+  def debugCode[A](c: LoggerContext[A])(body: c.Expr[Unit])(a: c.Expr[A]): c.universe.Tree = {
+    import c.universe._
+    val underlying = q"${c.prefix}.underlying"
+    val canLogEv = q"${c.prefix}.canLogEv"
+    q"""if ($underlying.isDebugEnabled) {
+          $underlying.debug($canLogEv.logMessage($body))
+          $canLogEv.afterLog($a)
+        }"""
+  }
+
+
   // Trace
 
   def traceMessage[A](c: LoggerContext[A])(message: c.Expr[String])(a: c.Expr[A]): c.universe.Tree = {
@@ -385,5 +426,15 @@ private[scalalogging] object LoggerTakingImplicitMacro {
           $canLogEv.afterLog($a)
         }"""
     }
+  }
+
+  def traceCode[A](c: LoggerContext[A])(body: c.Expr[Unit])(a: c.Expr[A]): c.universe.Tree = {
+    import c.universe._
+    val underlying = q"${c.prefix}.underlying"
+    val canLogEv = q"${c.prefix}.canLogEv"
+    q"""if ($underlying.isTraceEnabled) {
+          $underlying.trace($canLogEv.logMessage($body))
+          $canLogEv.afterLog($a)
+        }"""
   }
 }

--- a/src/main/scala-2/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
+++ b/src/main/scala-2/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
@@ -351,7 +351,6 @@ private[scalalogging] object LoggerTakingImplicitMacro {
         }"""
   }
 
-
   // Trace
 
   def traceMessage[A](c: LoggerContext[A])(message: c.Expr[String])(a: c.Expr[A]): c.universe.Tree = {

--- a/src/main/scala-3/com/typesafe/scalalogging/LoggerTakingImplicitImpl.scala
+++ b/src/main/scala-3/com/typesafe/scalalogging/LoggerTakingImplicitImpl.scala
@@ -27,7 +27,7 @@ trait LoggerTakingImplicitImpl[A] {
   inline def error(inline marker: Marker, inline message: String, inline args: Any*)(implicit inline a: A): Unit =
     ${LoggerTakingImplicitMacro.errorMessageArgsMarker('underlying, 'canLogEv, 'marker,'message, 'args)('a)}
 
-
+  inline def whenErrorEnabled(inline body: Unit)(implicit inline a: A): Unit = ${LoggerTakingImplicitMacro.errorCode('underlying, 'canLogEv, 'body)('a)}
 
   // Warn
 
@@ -48,6 +48,8 @@ trait LoggerTakingImplicitImpl[A] {
 
   inline def warn(inline marker: Marker, inline message: String, inline args: Any*)(implicit inline a: A): Unit =
     ${LoggerTakingImplicitMacro.warnMessageArgsMarker('underlying, 'canLogEv, 'marker,'message, 'args)('a)}
+
+  inline def whenWarnEnabled(inline body: Unit)(implicit inline a: A): Unit = ${LoggerTakingImplicitMacro.warnCode('underlying, 'canLogEv, 'body)('a)}
 
 
 
@@ -71,6 +73,7 @@ trait LoggerTakingImplicitImpl[A] {
   inline def info(inline marker: Marker, inline message: String, inline args: Any*)(implicit inline a: A): Unit =
     ${LoggerTakingImplicitMacro.infoMessageArgsMarker('underlying, 'canLogEv, 'marker,'message, 'args)('a)}
 
+  inline def whenInfoEnabled(inline body: Unit)(implicit inline a: A): Unit = ${LoggerTakingImplicitMacro.infoCode('underlying, 'canLogEv, 'body)('a)}
 
 
   // Debug
@@ -93,7 +96,7 @@ trait LoggerTakingImplicitImpl[A] {
   inline def debug(inline marker: Marker, inline message: String, inline args: Any*)(implicit inline a: A): Unit =
     ${LoggerTakingImplicitMacro.debugMessageArgsMarker('underlying, 'canLogEv, 'marker,'message, 'args)('a)}
 
-
+  inline def whenDebugEnabled(inline body: Unit)(implicit inline a: A): Unit = ${LoggerTakingImplicitMacro.debugCode('underlying, 'canLogEv, 'body)('a)}
 
   // Trace
 
@@ -114,4 +117,6 @@ trait LoggerTakingImplicitImpl[A] {
 
   inline def trace(inline marker: Marker, inline message: String, inline args: Any*)(implicit inline a: A): Unit =
     ${LoggerTakingImplicitMacro.traceMessageArgsMarker('underlying, 'canLogEv, 'marker,'message, 'args)('a)}
+
+  inline def whenTraceEnabled(inline body: Unit)(implicit inline a: A): Unit = ${LoggerTakingImplicitMacro.traceCode('underlying, 'canLogEv, 'body)('a)}
 }

--- a/src/main/scala-3/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
+++ b/src/main/scala-3/com/typesafe/scalalogging/LoggerTakingImplicitMacro.scala
@@ -60,8 +60,11 @@ private[scalalogging] object LoggerTakingImplicitMacro {
         }}
   }
 
-
-
+  def errorCode[A:Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], body: Expr[Unit])(a: Expr[A])(using Quotes) =
+    '{if ($underlying.isErrorEnabled) {
+          $body
+          $canLogEv.afterLog($a)
+        }}
 
   // Warn
 
@@ -117,9 +120,13 @@ private[scalalogging] object LoggerTakingImplicitMacro {
         }}
   }
 
+  def warnCode[A: Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], body: Expr[Unit])(a: Expr[A])(using Quotes) =
+      '{ if ($underlying.isWarnEnabled) {
+            $body
+            $canLogEv.afterLog($a)
+          }}
 
 
-  
   // Info
 
   def infoMessage[A: Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], message: Expr[String])(a: Expr[A])(using Quotes): Expr[Unit] =
@@ -174,9 +181,13 @@ private[scalalogging] object LoggerTakingImplicitMacro {
         }}
   }
 
+  def infoCode[A: Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], body: Expr[Unit])(a: Expr[A])(using Quotes) =
+      '{ if ($underlying.isInfoEnabled) {
+            $body
+            $canLogEv.afterLog($a)
+          }}
 
 
-  
   // Debug
 
   def debugMessage[A: Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], message: Expr[String])(a: Expr[A])(using Quotes): Expr[Unit] =
@@ -231,9 +242,13 @@ private[scalalogging] object LoggerTakingImplicitMacro {
         }}
   }
 
+  def debugCode[A: Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], body: Expr[Unit])(a: Expr[A])(using Quotes) =
+      '{ if ($underlying.isDebugEnabled) {
+        $body
+        $canLogEv.afterLog($a)
+      }}
 
-  
-  
+
   // Trace
 
   def traceMessage[A: Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], message: Expr[String])(a: Expr[A])(using Quotes): Expr[Unit] =
@@ -287,4 +302,10 @@ private[scalalogging] object LoggerTakingImplicitMacro {
           $canLogEv.afterLog($a)
         }}
   }
+
+  def traceCode[A: Type](underlying: Expr[Underlying], canLogEv: Expr[CanLog[A]], body: Expr[Unit])(a: Expr[A])(using Quotes) =
+      '{ if ($underlying.isTraceEnabled) {
+        $body
+        $canLogEv.afterLog($a)
+      }}
 }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
References #292 
I have noticed that these `when***Enabled()` methods were also missing from [LoggerTakingImplicitImpl](https://github.com/lightbend/scala-logging/blob/main/src/main/scala-3/com/typesafe/scalalogging/LoggerTakingImplicitImpl.scala) under [scala-3/com/typesafe/scalalogging](https://github.com/lightbend/scala-logging/tree/main/src/main/scala-3/com/typesafe/scalalogging) package. So i have added them there as well.